### PR TITLE
Introducing: Leady McBreadcrumbs

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
+++ b/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
@@ -34,6 +34,7 @@ class ParadoxProcessor(reader: Reader = new Reader, writer: Writer = new Writer)
    * Process all mappings to build the site.
    */
   def process(mappings: Seq[(File, String)],
+              leadingBreadcrumbs: List[(String, String)],
               outputDirectory: File,
               sourceSuffix: String,
               targetSuffix: String,
@@ -50,7 +51,7 @@ class ParadoxProcessor(reader: Reader = new Reader, writer: Writer = new Writer)
         val writerContext = Writer.Context(loc, paths, sourceSuffix, targetSuffix, properties)
         val pageToc = new TableOfContents(pages = true, headers = false, ordered = false, maxDepth = navigationDepth)
         val headerToc = new TableOfContents(pages = false, headers = true, ordered = false, maxDepth = navigationDepth)
-        val pageContext = PageContents(loc, writer, writerContext, pageToc, headerToc)
+        val pageContext = PageContents(leadingBreadcrumbs, loc, writer, writerContext, pageToc, headerToc)
         val outputFile = new File(outputDirectory, page.path)
         outputFile.getParentFile.mkdirs
         template.write(pageContext, outputFile, errorListener)
@@ -63,7 +64,7 @@ class ParadoxProcessor(reader: Reader = new Reader, writer: Writer = new Writer)
   /**
    * Default template contents for a markdown page at a particular location.
    */
-  case class PageContents(loc: Location[Page], writer: Writer, context: Writer.Context, pageToc: TableOfContents, headerToc: TableOfContents) extends PageTemplate.Contents {
+  case class PageContents(leadingBreadcrumbs: List[(String, String)], loc: Location[Page], writer: Writer, context: Writer.Context, pageToc: TableOfContents, headerToc: TableOfContents) extends PageTemplate.Contents {
     import scala.collection.JavaConverters._
 
     private val page = loc.tree.label
@@ -75,7 +76,7 @@ class ParadoxProcessor(reader: Reader = new Reader, writer: Writer = new Writer)
     lazy val getHome = link(Some(loc.root))
     lazy val getPrev = link(loc.prev)
     lazy val getNext = link(loc.next)
-    lazy val getBreadcrumbs = writer.writeFragment(Breadcrumbs.markdown(loc.path), context)
+    lazy val getBreadcrumbs = writer.writeFragment(Breadcrumbs.markdown(leadingBreadcrumbs, loc.path), context)
     lazy val getNavigation = writer.writeFragment(pageToc.root(loc), context)
     lazy val hasSubheaders = page.headers.nonEmpty
     lazy val getToc = writer.writeFragment(headerToc.headers(loc), context)

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Breadcrumbs.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Breadcrumbs.scala
@@ -16,6 +16,8 @@
 
 package com.lightbend.paradox.markdown
 
+import scala.collection.JavaConverters._
+
 import com.lightbend.paradox.tree.Tree.Location
 import org.pegdown.ast._
 
@@ -38,17 +40,12 @@ object Breadcrumbs {
   }
 
   private def list(items: List[ListItemNode]): BulletListNode = {
-    val parent = new SuperNode
-    items.foreach(parent.getChildren.add)
-    new BulletListNode(parent)
+    new BulletListNode(new SuperNode(items.map(n => n: Node).asJava))
   }
 
   private def item(base: String, active: String)(location: Location[Page]): ListItemNode = {
     val page = location.tree.label
-    val label = link(base, page.path, page.label, active)
-    val parent = new SuperNode
-    parent.getChildren.add(label)
-    new ListItemNode(parent)
+    new ListItemNode(new SuperNode(link(base, page.path, page.label, active)))
   }
 
   private def link(base: String, path: String, label: Node, active: String): Node = {

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Breadcrumbs.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Breadcrumbs.scala
@@ -30,27 +30,35 @@ object Breadcrumbs {
    * Convert a location path into a markdown list.
    * Note: locations are ordered from current location up to root.
    */
-  def markdown(locations: List[Location[Page]]): BulletListNode = locations match {
-    case current :: parents => crumbs(current.tree.label.base, current.tree.label.path, locations.reverse)
-    case _                  => list(Nil)
-  }
+  def markdown(leadingBreadcrumbs: List[(String, String)], locations: List[Location[Page]]): BulletListNode =
+    locations match {
+      case current :: parents => crumbs(current.tree.label.base, current.tree.label.path, leadingBreadcrumbs, locations.reverse)
+      case _                  => list(Nil)
+    }
 
-  private def crumbs(base: String, active: String, locations: List[Location[Page]]): BulletListNode = {
-    list(locations map item(base, active))
+  private def crumbs(base: String, active: String, leadingBreadcrumbs: List[(String, String)], locations: List[Location[Page]]): BulletListNode = {
+    val lead = leadingBreadcrumbs map { case (label, url) => item(url, "", labelNode(label), active) }
+    list(lead ++ (locations map pageItem(base, active)))
   }
 
   private def list(items: List[ListItemNode]): BulletListNode = {
     new BulletListNode(new SuperNode(items.map(n => n: Node).asJava))
   }
 
-  private def item(base: String, active: String)(location: Location[Page]): ListItemNode = {
+  private def pageItem(base: String, active: String)(location: Location[Page]): ListItemNode = {
     val page = location.tree.label
-    new ListItemNode(new SuperNode(link(base, page.path, page.label, active)))
+    item(base + page.path, page.path, page.label, active)
   }
 
-  private def link(base: String, path: String, label: Node, active: String): Node = {
-    if (path == active) label // no link for current location
-    else new ExpLinkNode("", base + path, label)
+  private def item(url: String, path: String, label: Node, active: String): ListItemNode = {
+    new ListItemNode(new SuperNode(link(url, path, label, active)))
   }
+
+  private def link(url: String, path: String, label: Node, active: String): Node = {
+    if (path == active) label // no link for current location
+    else new ExpLinkNode("", url, label)
+  }
+
+  private def labelNode(label: String): Node = new SuperNode(new TextNode(label))
 
 }

--- a/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxKeys.scala
+++ b/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxKeys.scala
@@ -24,6 +24,7 @@ trait ParadoxKeys {
   val paradox = taskKey[File]("Build the paradox site.")
   val paradoxMarkdownToHtml = taskKey[Seq[(File, String)]]("Convert markdown files to HTML.")
   val paradoxNavigationDepth = settingKey[Int]("Determines depth of TOC for page navigation.")
+  val paradoxLeadingBreadcrumbs = settingKey[List[(String, String)]]("Any leading breadcrumbs (label -> url)")
   val paradoxOrganization = settingKey[String]("Paradox dependency organization (for theme dependencies).")
   val paradoxProcessor = taskKey[ParadoxProcessor]("ParadoxProcessor to use when generating the site.")
   val paradoxProperties = taskKey[Map[String, String]]("Property map passed to paradox.")

--- a/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
+++ b/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
@@ -45,6 +45,7 @@ object ParadoxPlugin extends AutoPlugin {
     paradoxNavigationDepth := 2,
     paradoxProperties := Map.empty,
     paradoxTheme := None,
+    paradoxLeadingBreadcrumbs := Nil,
     libraryDependencies ++= paradoxTheme.value.toSeq
   )
 
@@ -108,6 +109,7 @@ object ParadoxPlugin extends AutoPlugin {
       IO.delete((target in paradoxMarkdownToHtml).value)
       paradoxProcessor.value.process(
         (mappings in paradoxMarkdownToHtml).value,
+        paradoxLeadingBreadcrumbs.value,
         (target in paradoxMarkdownToHtml).value,
         paradoxSourceSuffix.value,
         paradoxTargetSuffix.value,

--- a/plugin/src/sbt-test/paradox/site/build.sbt
+++ b/plugin/src/sbt-test/paradox/site/build.sbt
@@ -2,5 +2,6 @@ lazy val docs = project
   .in(file("."))
   .enablePlugins(ParadoxPlugin)
   .settings(
-    name := "Paradox Test"
+    name := "Paradox Test",
+    paradoxLeadingBreadcrumbs := List("Alphabet" -> "https://abc.xyz/", "Google" -> "https://www.google.com")
   )

--- a/plugin/src/sbt-test/paradox/site/expected/a.html
+++ b/plugin/src/sbt-test/paradox/site/expected/a.html
@@ -9,6 +9,8 @@
 <a href="a.html" class="active">A</a>
 0.1-SNAPSHOT
 <ul>
+  <li><a href="https://abc.xyz/">Alphabet</a></li>
+  <li><a href="https://www.google.com">Google</a></li>
   <li>A</li>
 </ul>
 <ul>

--- a/plugin/src/sbt-test/paradox/site/expected/a/a.html
+++ b/plugin/src/sbt-test/paradox/site/expected/a/a.html
@@ -9,6 +9,8 @@
 <a href="../a.html">A</a>
 0.1-SNAPSHOT
 <ul>
+  <li><a href="https://abc.xyz/">Alphabet</a></li>
+  <li><a href="https://www.google.com">Google</a></li>
   <li><a href="../a.html">A</a></li>
   <li>AA</li>
 </ul>

--- a/plugin/src/sbt-test/paradox/site/expected/a/b.html
+++ b/plugin/src/sbt-test/paradox/site/expected/a/b.html
@@ -9,6 +9,8 @@
 <a href="../a.html">A</a>
 0.1-SNAPSHOT
 <ul>
+  <li><a href="https://abc.xyz/">Alphabet</a></li>
+  <li><a href="https://www.google.com">Google</a></li>
   <li><a href="../a.html">A</a></li>
   <li><a href="../a/a.html">AA</a></li>
   <li>AB</li>

--- a/plugin/src/sbt-test/paradox/site/expected/a/c.html
+++ b/plugin/src/sbt-test/paradox/site/expected/a/c.html
@@ -9,6 +9,8 @@
 <a href="../a.html">A</a>
 0.1-SNAPSHOT
 <ul>
+  <li><a href="https://abc.xyz/">Alphabet</a></li>
+  <li><a href="https://www.google.com">Google</a></li>
   <li><a href="../a.html">A</a></li>
   <li><a href="../a/a.html">AA</a></li>
   <li>AC</li>

--- a/plugin/src/sbt-test/paradox/site/expected/b/a.html
+++ b/plugin/src/sbt-test/paradox/site/expected/b/a.html
@@ -9,6 +9,8 @@
 <a href="../a.html">A</a>
 0.1-SNAPSHOT
 <ul>
+  <li><a href="https://abc.xyz/">Alphabet</a></li>
+  <li><a href="https://www.google.com">Google</a></li>
   <li><a href="../a.html">A</a></li>
   <li>BA</li>
 </ul>

--- a/plugin/src/sbt-test/paradox/site/expected/b/a/a.html
+++ b/plugin/src/sbt-test/paradox/site/expected/b/a/a.html
@@ -9,6 +9,8 @@
 <a href="../../a.html">A</a>
 0.1-SNAPSHOT
 <ul>
+  <li><a href="https://abc.xyz/">Alphabet</a></li>
+  <li><a href="https://www.google.com">Google</a></li>
   <li><a href="../../a.html">A</a></li>
   <li><a href="../../b/a.html">BA</a></li>
   <li>BAA</li>

--- a/plugin/src/sbt-test/paradox/site/expected/b/b.html
+++ b/plugin/src/sbt-test/paradox/site/expected/b/b.html
@@ -9,6 +9,8 @@
 <a href="../a.html">A</a>
 0.1-SNAPSHOT
 <ul>
+  <li><a href="https://abc.xyz/">Alphabet</a></li>
+  <li><a href="https://www.google.com">Google</a></li>
   <li><a href="../a.html">A</a></li>
   <li><a href="../b/a.html">BA</a></li>
   <li>BB</li>


### PR DESCRIPTION
If a documentation site is contained within an enclosing website it's very pleasant if the breadcrumbs allows one to navigate back up.

This introduces this as a first class concept within Paradox.

---

Despite how nicely Paradox is coded, I had a little trouble figuring out how to implement this. Please consider this a first draft and I very much welcome feedback, including feedback about how to completely re-do this. The only thing I'm happy with is that it achieves the end goal (in the test).