### PR TITLE
Consistently render content inside callouts, fixes #49

### DIFF
--- a/core/src/main/java/org/pegdown/ParserWithDirectives.java
+++ b/core/src/main/java/org/pegdown/ParserWithDirectives.java
@@ -154,7 +154,7 @@ public class ParserWithDirectives extends Parser {
             push(getContext().getCurrentIndex()),
             contents.clearContents(),
             OneOrMore(TestNot(ContainerBlockDirectiveEnd(markerLength)), ANY, contents.append(matchedChar())),
-            push(parseBlockContents(markerLength, contents.appended("\n")))
+            push(parseBlockContents(markerLength, contents.appended("\n\n")))
         );
     }
 

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
@@ -119,7 +119,7 @@ object Writer {
     VarsDirective(context.properties),
     CalloutDirective("note", "Note"),
     CalloutDirective("warning", "Warning"),
-    WrapDirective("div"), WrapDirective("p"))
+    WrapDirective("div"))
 
   class DefaultLinkRenderer(context: Context) extends LinkRenderer {
     private lazy val imgBase = {

--- a/core/src/test/scala/com/lightbend/paradox/markdown/CalloutDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/CalloutDirectiveSpec.scala
@@ -34,7 +34,36 @@ class CalloutDirectiveSpec extends MarkdownBaseSpec {
       """) shouldEqual html("""
       |<div class="callout note">
       |<div class="callout-title">Note</div>
-      |Latest version is 1.2.3
+      |<p>Latest version is 1.2.3</p>
+      |</div>
+      """)
+
+    markdown("""
+      |@@@ note
+      |
+      |Latest version is @var[version]
+      |
+      |@@@
+      """) shouldEqual html("""
+      |<div class="callout note">
+      |<div class="callout-title">Note</div>
+      |<p>Latest version is 1.2.3</p>
+      |</div>
+      """)
+  }
+
+  it should "render notes regardless of new lines at start/end" in {
+    markdown("""
+      |@@@ note
+      |Latest version is @var[version]
+      |
+      |Get it while it is hot!
+      |@@@
+      """) shouldEqual html("""
+      |<div class="callout note">
+      |<div class="callout-title">Note</div>
+      |<p>Latest version is 1.2.3</p>
+      |<p>Get it while it is hot!</p>
       |</div>
       """)
   }
@@ -77,7 +106,7 @@ class CalloutDirectiveSpec extends MarkdownBaseSpec {
       """) shouldEqual html("""
       |<div class="callout warning">
       |<div class="callout-title">Warning</div>
-      |Version 1.2.3 is deprecated!
+      |<p>Version 1.2.3 is deprecated!</p>
       |</div>
       """)
   }

--- a/core/src/test/scala/com/lightbend/paradox/markdown/WrapDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/WrapDirectiveSpec.scala
@@ -32,18 +32,20 @@ class WrapDirectiveSpec extends MarkdownBaseSpec {
       |Simple sentence here.
       |@@@""") shouldEqual html("""
       |<div>
-      |Simple sentence here.
+      |<p>Simple sentence here.</p>
       |</div>""")
   }
 
-  it should "render wrapping `p`s with a custom `id`" in {
+  it should "render the example from the docs" in {
     markdown("""
-      |@@@ p { #yeah }
-      |Simple sentence here.
+      |@@@ div { #foo .bar .baz }
+      |
+      |Inner **markdown** content.
+      |
       |@@@""") shouldEqual html("""
-      |<p id="yeah">
-      |Simple sentence here.
-      |</p>""")
+      |<div id="foo" class="bar baz">
+      |<p>Inner <strong>markdown</strong> content.</p>
+      |</div>""")
   }
 
   it should "support a custom id and custom CSS classes at the same time" in {
@@ -52,7 +54,7 @@ class WrapDirectiveSpec extends MarkdownBaseSpec {
       |Simple sentence here.
       |@@@""") shouldEqual html("""
       |<div id="yeah" class="red blue">
-      |Simple sentence here.
+      |<p>Simple sentence here.</p>
       |</div>""")
   }
 

--- a/docs/src/main/paradox/features/callouts.md
+++ b/docs/src/main/paradox/features/callouts.md
@@ -20,7 +20,7 @@ pool has no pending requests waiting.
 @@@
 ```
 
-will render as:
+and will render as:
 
 @@@ note
 

--- a/docs/src/main/paradox/features/css-friendliness.md
+++ b/docs/src/main/paradox/features/css-friendliness.md
@@ -5,8 +5,8 @@ Regular markdown has no syntax for attaching identifiers or CSS classes to docum
 While this keeps a document output-format-agnostic in principle, it can also make the CSS styling of the generated HTML
 difficult and brittle.
 
-*paradox* comes with two "wrapping directives" which address this problem by allow you to introduce additional
-`div` or `p` container elements, with custom `id` or `class` attributes, at arbitrary points in the document structure.
+Paradox comes with a "wrapping directive" which addresses this problem by allowing you to introduce additional
+`div` elements, with custom `id` or `class` attributes, at arbitrary points in the document structure.
 
 
 ### @@@ div
@@ -15,7 +15,7 @@ Wrapping content with `@@@ div`, e.g. like this:
 
 ```markdown
 @@@ div { #foo .bar .baz }
- 
+
 Inner **markdown** content.
 
 @@@
@@ -27,43 +27,4 @@ will render as:
 <div id="foo" class="bar baz">
   <p>Inner <strong>markdown</strong> content.</p>    
 </div>
-```
-
-By omitting the extra blank lines you can prevent the addition of the extra `<p>..</p>` wrapper.
-So this:
-  
-```markdown
-@@@ div { #foo .bar .baz }
-Inner **markdown** content.
-@@@
-```
-
-will render as:
-
-```html
-<div id="foo" class="bar baz">
-Inner <strong>markdown</strong> content.    
-</div>
-```
-
-
-### @@@ p
-
-The `@@@ p` directive works in exactly the same way as `@@@ div`, with the only difference that it generates a
-`<p>...</p>` wrapper rather than a `<div>...</div>`.
-
-For example this snippet:
-  
-```markdown
-@@@ p { #foo .bar .baz }
-Inner **markdown** content.
-@@@
-```
-
-will render as:
-
-```html
-<p id="foo" class="bar baz">
-Inner <strong>markdown</strong> content.    
-</p>
 ```

--- a/notes/0.2.7.markdown
+++ b/notes/0.2.7.markdown
@@ -1,8 +1,42 @@
-### Enhancements
+### Fixes and enhancements
 
-- Add `@javadoc` parameterized link directive. [#43][43] by [@jonas][@jonas]
-- Provide ability to disable prettify code highlighting [#64][64] by [@jonas][@jonas]
+- Support referenced source definitions. [#59][59] by [@sirthias]
+- Add `@javadoc` parameterized link directive. [#52][52] by [@jonas][@jonas]
+- Provide ability to disable prettify code highlighting. [#64][64] by [@jonas][@jonas]
+- Consistently render content inside block directives. [#51][51] by [@jonas][@jonas]
 
-  [43]: https://github.com/lightbend/paradox/issues/43
-  [64]: https://github.com/lightbend/paradox/issues/64
+### Referenced source definitions
+
+One core markdown feature is support for defining link targets in two
+ways: either in parens directly following the link text or through a
+reference key following the link text in brackets. The first way was always
+supported and this addition allows the second way for Paradox's various
+link directives, such as `@ref`, `@extref` and `@scaladoc`.
+
+```markdown
+Before continuing please read @ref:[the best practices][best-practices] for
+using actors as well as the @scaladoc:[Actor API docs][Actor].
+
+  [Actor]: akka.actor.Actor
+  [best-practices]: actor-systems.md#actor-best-practices
+```
+
+### Disabling code highlighting
+
+In certain cases, fenced code blocks were eagerly highlighted even when a
+specific language was specified. This behaviour can be disabled by explicitly
+specifying `text` as the language type. For example:
+
+    ```text
+    Content which should not be highlighted.
+    ```
+
+    @@snip [example.log](example.log) { #example-log type=text }
+
+
+  [51]: https://github.com/lightbend/paradox/pull/51
+  [52]: https://github.com/lightbend/paradox/pull/52
+  [59]: https://github.com/lightbend/paradox/pull/59
+  [64]: https://github.com/lightbend/paradox/pull/64
   [@jonas]: https://github.com/jonas
+  [@sirthias]: https://github.com/sirthias


### PR DESCRIPTION
Wrap inner block content in new lines to force consistent parsing of @@@
directives in particular callouts which renders the content directly.