### PR TITLE
Add directive for wrapping content in `div` or `p` elements ...

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -406,7 +406,7 @@ case class VarsDirective(variables: Map[String, String]) extends ContainerBlockD
 /**
  * Callout directive.
  *
- * Replaces property values in verbatim blocks.
+ * Renders call-out divs.
  */
 case class CalloutDirective(name: String, defaultTitle: String) extends ContainerBlockDirective(Array(name): _*) {
   def render(node: DirectiveNode, visitor: Visitor, printer: Printer): Unit = {
@@ -417,5 +417,28 @@ case class CalloutDirective(name: String, defaultTitle: String) extends Containe
     printer.print(s"""<div class="callout-title">$title</div>""")
     node.contentsNode.accept(visitor)
     printer.print("""</div>""")
+  }
+}
+
+/**
+ * Wrap directive.
+ *
+ * Wraps inner content in a `div` or `p`, optionally with custom `id` and/or `class` attributes.
+ */
+case class WrapDirective(typ: String) extends ContainerBlockDirective(Array(typ, typ.toUpperCase): _*) {
+  def render(node: DirectiveNode, visitor: Visitor, printer: Printer): Unit = {
+    val id =
+      node.attributes.identifier match {
+        case null => ""
+        case x    => s""" id="$x""""
+      }
+    val classes =
+      node.attributes.classesString match {
+        case "" => ""
+        case x  => s""" class="$x""""
+      }
+    printer.print(s"""<$typ$id$classes>""")
+    node.contentsNode.accept(visitor)
+    printer.print(s"</$typ>")
   }
 }

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
@@ -117,8 +117,8 @@ object Writer {
     VarDirective(context.properties),
     VarsDirective(context.properties),
     CalloutDirective("note", "Note"),
-    CalloutDirective("warning", "Warning")
-  )
+    CalloutDirective("warning", "Warning"),
+    WrapDirective("div"), WrapDirective("p"))
 
   class DefaultLinkRenderer(context: Context) extends LinkRenderer {
     private lazy val imgBase = {

--- a/core/src/test/scala/com/lightbend/paradox/markdown/WrapDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/WrapDirectiveSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.paradox.markdown
+
+import com.lightbend.paradox.tree.Tree.Location
+
+class WrapDirectiveSpec extends MarkdownBaseSpec {
+
+  val testProperties = Map("version" -> "1.2.3")
+
+  implicit val context: Location[Page] => Writer.Context = { loc =>
+    writerContext(loc).copy(properties = testProperties)
+  }
+
+  "The `wrap` directive" should "render wrapping `div`s" in {
+    markdown("""
+      |@@@ div
+      |Simple sentence here.
+      |@@@""") shouldEqual html("""
+      |<div>
+      |Simple sentence here.
+      |</div>""")
+  }
+
+  it should "render wrapping `p`s with a custom `id`" in {
+    markdown("""
+      |@@@ p { #yeah }
+      |Simple sentence here.
+      |@@@""") shouldEqual html("""
+      |<p id="yeah">
+      |Simple sentence here.
+      |</p>""")
+  }
+
+  it should "support a custom id and custom CSS classes at the same time" in {
+    markdown("""
+      |@@@ div { #yeah .red .blue }
+      |Simple sentence here.
+      |@@@""") shouldEqual html("""
+      |<div id="yeah" class="red blue">
+      |Simple sentence here.
+      |</div>""")
+  }
+
+}

--- a/docs/src/main/paradox/features/css-friendliness.md
+++ b/docs/src/main/paradox/features/css-friendliness.md
@@ -1,0 +1,69 @@
+CSS Friendliness
+----------------
+
+Regular markdown has no syntax for attaching identifiers or CSS classes to document tree elements.
+While this keeps a document output-format-agnostic in principle, it can also make the CSS styling of the generated HTML
+difficult and brittle.
+
+*paradox* comes with two "wrapping directives" which address this problem by allow you to introduce additional
+`div` or `p` container elements, with custom `id` or `class` attributes, at arbitrary points in the document structure.
+
+
+### @@@ div
+
+Wrapping content with `@@@ div`, e.g. like this:
+
+```markdown
+@@@ div { #foo .bar .baz }
+ 
+Inner **markdown** content.
+
+@@@
+```
+
+will render as:
+
+```html
+<div id="foo" class="bar baz">
+  <p>Inner <strong>markdown</strong> content.</p>    
+</div>
+```
+
+By omitting the extra blank lines you can prevent the addition of the extra `<p>..</p>` wrapper.
+So this:
+  
+```markdown
+@@@ div { #foo .bar .baz }
+Inner **markdown** content.
+@@@
+```
+
+will render as:
+
+```html
+<div id="foo" class="bar baz">
+Inner <strong>markdown</strong> content.    
+</div>
+```
+
+
+### @@@ p
+
+The `@@@ p` directive works in exactly the same way as `@@@ div`, with the only difference that it generates a
+`<p>...</p>` wrapper rather than a `<div>...</div>`.
+
+For example this snippet:
+  
+```markdown
+@@@ p { #foo .bar .baz }
+Inner **markdown** content.
+@@@
+```
+
+will render as:
+
+```html
+<p id="foo" class="bar baz">
+Inner <strong>markdown</strong> content.    
+</p>
+```

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -53,6 +53,7 @@ which basically means that all of our extensions would start with `@` (for inlin
 * [Linking](features/linking.md)
 * [Snippet inclusion](features/snippet-inclusion.md)
 * [Callouts](features/callouts.md)
+* [CSS Friendliness](features/css-friendliness.md)
 * [Templating](features/templating.md)
 * [Theming](features/theming.md)
 


### PR DESCRIPTION
… with custom ids and/or CSS classes.

I've always wanted to have the ability to introduce custom container elements (with custom ids/classes) at arbitrary levels in the HTML node tree. Unfortunately pegdown itself doesn't support this, but paradox's directives make it easy.

Hopefully this addition doesn't clash with any output-agnostic vision you might have for paradox as it definitely increases the coupling to HTML.