### PR TITLE
Add support for referenced source definition …

### DIFF
--- a/core/src/main/java/org/pegdown/ast/DirectiveNode.java
+++ b/core/src/main/java/org/pegdown/ast/DirectiveNode.java
@@ -31,16 +31,16 @@ public class DirectiveNode extends AbstractNode {
     public final Format format;
     public final String name;
     public final String label;
-    public final String source;
+    public final Source source;
     public final DirectiveAttributes attributes;
     public final String contents;
     public final Node contentsNode;
 
-    public DirectiveNode(Format format, String name, String label, String source, DirectiveAttributes attributes, Node labelNode) {
+    public DirectiveNode(Format format, String name, String label, Source source, DirectiveAttributes attributes, Node labelNode) {
         this(format, name, label, source, attributes, label, labelNode);
     }
 
-    public DirectiveNode(Format format, String name, String label, String source, DirectiveAttributes attributes, String contents, Node contentsNode) {
+    public DirectiveNode(Format format, String name, String label, Source source, DirectiveAttributes attributes, String contents, Node contentsNode) {
         this.format = format;
         this.name = name;
         this.label = label;
@@ -66,12 +66,33 @@ public class DirectiveNode extends AbstractNode {
         if (!label.isEmpty()) {
             sb.append(" [" + StringUtils.escape(label) + "]");
         }
-        if (!source.isEmpty()) {
-            sb.append(" (" + StringUtils.escape(source) + ")");
-        }
+        source.format(sb);
         if (!attributes.isEmpty()) {
             sb.append(" " + attributes.toString());
         }
         return sb.toString();
+    }
+
+    /**
+     * Poor man's ADT ...
+     */
+    public static abstract class Source {
+        public abstract void format(StringBuilder sb);
+
+        public static final class Direct extends Source {
+            public final String value;
+            public Direct(String value) { this.value = value; }
+            public void format(StringBuilder sb) { sb.append('(').append(StringUtils.escape(value)).append(')'); }
+        }
+
+        public static final class Ref extends Source {
+            public final String value;
+            public Ref(String value) { this.value = value; }
+            public void format(StringBuilder sb) { sb.append('[').append(value).append(']'); }
+        }
+
+        public static final Source Empty = new Source() {
+            public void format(StringBuilder sb) { }
+        };
     }
 }

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
@@ -107,10 +107,10 @@ object Writer {
   )
 
   def defaultDirectives(context: Context): Seq[Directive] = Seq(
-    RefDirective(context.location.tree.label.path, context.paths, context.pageMappings),
-    ExtRefDirective(context.location.tree.label.path, context.properties),
-    ScaladocDirective(context.location.tree.label.path, context.properties),
-    GitHubDirective(context.location.tree.label.path, context.properties),
+    RefDirective(context.location.tree.label, context.paths, context.pageMappings),
+    ExtRefDirective(context.location.tree.label, context.properties),
+    ScaladocDirective(context.location.tree.label, context.properties),
+    GitHubDirective(context.location.tree.label, context.properties),
     SnipDirective(context.location.tree.label, context.properties),
     FiddleDirective(context.location.tree.label),
     TocDirective(context.location),

--- a/core/src/test/scala/com/lightbend/paradox/markdown/ExtRefDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/ExtRefDirectiveSpec.scala
@@ -16,8 +16,6 @@
 
 package com.lightbend.paradox.markdown
 
-import com.lightbend.paradox.tree.Tree.Location
-
 class ExtRefDirectiveSpec extends MarkdownBaseSpec {
 
   implicit val context = writerContextWithProperties(
@@ -84,4 +82,11 @@ class ExtRefDirectiveSpec extends MarkdownBaseSpec {
     } should have message "Failed to resolve [broken:link] referenced from [test.html] because template resulted in an invalid URL [https://c|link]"
   }
 
+  it should "support referenced links" in {
+    markdown(
+      """@extref[RFC 1234] says it all!
+        |
+        |  [rfc 1234]: rfc:1234
+      """.stripMargin) shouldEqual html("""<p><a href="http://tools.ietf.org/html/rfc1234">RFC 1234</a> says it all!</p>""")
+  }
 }

--- a/core/src/test/scala/com/lightbend/paradox/markdown/GitHubDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/GitHubDirectiveSpec.scala
@@ -16,9 +16,7 @@
 
 package com.lightbend.paradox.markdown
 
-import com.lightbend.paradox.tree.Tree.Location
-
-class GibHubDirectiveSpec extends MarkdownBaseSpec {
+class GitHubDirectiveSpec extends MarkdownBaseSpec {
 
   implicit val context = writerContextWithProperties(
     "github.base_url" -> "https://github.com/lightbend/paradox/tree/v0.2.1")
@@ -92,4 +90,12 @@ class GibHubDirectiveSpec extends MarkdownBaseSpec {
     } should have message "Failed to resolve [#1] referenced from [test.html] because property [github.base_url] contains an invalid URL [https://github.com/broken/project|]"
   }
 
+  it should "support referenced links" in {
+    markdown(
+      """@github[#1234][1]
+        |
+        |  [1]: akka/akka#1234
+      """.stripMargin) shouldEqual
+      html("""<p><a href="https://github.com/akka/akka/issues/1234">#1234</a></p>""")
+  }
 }

--- a/core/src/test/scala/com/lightbend/paradox/markdown/PagePropertiesSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/PagePropertiesSpec.scala
@@ -18,7 +18,7 @@ package com.lightbend.paradox.markdown
 
 import org.scalatest.{ FlatSpec, Matchers }
 
-class PropertiesSpec extends FlatSpec with Matchers {
+class PagePropertiesSpec extends FlatSpec with Matchers {
   def convertPath = Path.replaceSuffix(".md", ".html")_
 
   val propOut = Map("out" -> "newIndex.html")

--- a/core/src/test/scala/com/lightbend/paradox/markdown/RefDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/RefDirectiveSpec.scala
@@ -64,4 +64,33 @@ class RefDirectiveSpec extends MarkdownBaseSpec {
     } should have message "Unknown page [page.html] referenced from [test.html]"
   }
 
+  it should "support referenced links with implicit key" in {
+    testMarkdown(
+      """This @ref:[Page] { .ref a=1 } is linked.
+        |
+        |  [Page]: page.md#header
+      """.stripMargin) shouldEqual testHtml("""<p>This <a href="page.html#header">Page</a> is linked.</p>""")
+  }
+
+  it should "support referenced links with empty key" in {
+    testMarkdown(
+      """This @ref:[Page][] { .ref a=1 } is linked.
+        |
+        |  [Page]: page.md#header
+      """.stripMargin) shouldEqual testHtml("""<p>This <a href="page.html#header">Page</a> is linked.</p>""")
+  }
+
+  it should "support referenced links with defined key" in {
+    testMarkdown(
+      """This @ref:[Page][123] { .ref a=1 } is linked.
+        |
+        |  [123]: page.md#header
+      """.stripMargin) shouldEqual testHtml("""<p>This <a href="page.html#header">Page</a> is linked.</p>""")
+  }
+
+  it should "throw link exceptions for invalid reference keys" in {
+    the[RefDirective.LinkException] thrownBy {
+      markdown("@ref[Page][123]")
+    } should have message "Undefined reference key [123] in [test.html]"
+  }
 }

--- a/core/src/test/scala/com/lightbend/paradox/markdown/ScaladocDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/ScaladocDirectiveSpec.scala
@@ -16,8 +16,6 @@
 
 package com.lightbend.paradox.markdown
 
-import com.lightbend.paradox.tree.Tree.Location
-
 class ScaladocDirectiveSpec extends MarkdownBaseSpec {
 
   implicit val context = writerContextWithProperties(
@@ -70,4 +68,11 @@ class ScaladocDirectiveSpec extends MarkdownBaseSpec {
     } should have message "Failed to resolve [broken.URL] referenced from [test.html] because property [scaladoc.broken.base_url] contains an invalid URL [https://c|]"
   }
 
+  it should "support referenced links" in {
+    markdown(
+      """The @scaladoc:[Model][1] spec
+        |
+        |  [1]: org.example.Model
+      """.stripMargin) shouldEqual html("""<p>The <a href="http://example.org/api/0.1.2/#org.example.Model">Model</a> spec</p>""")
+  }
 }


### PR DESCRIPTION
… to all directives with `source` semantics, i.e. `@extref`, `@fiddle`, `@github`, `@ref`, `@scaladoc` and `@snip`.

One core markdown feature is support for defining link targets in two ways: either in parens directly following the link text or through a reference key following the link text in brackets.

So far paradox directives only supported the first alternative.
This patch adds the second.

(I'm assuming that directives which specify their source through reference keys would still be completely github-friendly!)