### PR TITLE
Add support for multiple snippet base directories via configurable placeholders

### DIFF
--- a/docs/src/main/paradox/features/snippet-inclusion.md
+++ b/docs/src/main/paradox/features/snippet-inclusion.md
@@ -58,20 +58,31 @@ should not be highlighted set `type=text` in the directive's attribute section:
 @@snip [example.log](example.log) { #example-log type=text }
 ```
 
-### snippet.base_dir
+### snip.*.base_dir
 
-In order to specify your snippet source paths off a certain base directory you can define a snippet.base_dir property either in the page's front matter or globally like this (for example):
+In order to specify your snippet source paths off certain base directories you can define placeholders
+either in the page's front matter or globally like this (for example):
 
 ```sbt
 paradoxProperties in Compile ++= Map(
-  "snippet.base_dir" -> s"${(sourceDirectory in Test).value}/scala/org/example"
+  "snip.foo.base_dir" -> "../../../some/dir",
+  "snip.test.base_dir" -> s"${(sourceDirectory in Test).value}/scala/org/example"
 )
 ```
 
-You can then refer to this snippet base directory by starting a snippet path with .../, e.g.
+You can then refer to one of the defined base directories by starting the snippet's target path with `$placeholder$`,
+for example:
 
 ```markdown
-@@snip [Hello.scala](.../Hello.scala) { #hello_example }
+@@snip [Hello.scala]($foo$/Hello.scala) { #hello_example }
+
+@@snip [Yeah.scala]($test$/Yeah.scala) { #yeah_example }
+
+@@snip [Yeah.scala]($root$/src/test/scala/org/example/Yeah.scala) { #yeah_example }
 ```
 
-**Note**: Using this feature will not allow GitHub to preview the images correctly on the web.
+If a placeholder directory is relative (like `$foo$` in this example) it'll be based of the path of the respective page
+it is used in. Also, *paradox* always auto-defines the placeholder `$root$` to denote the absolute path of the
+SBT project's root directory.
+
+**Note**: Using this feature will not allow GitHub to follow the snippet links correctly on the web UI.

--- a/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
+++ b/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
@@ -56,10 +56,12 @@ object ParadoxPlugin extends AutoPlugin {
     version in paradox := version.value,
     description in paradox := description.value,
 
-    paradoxProperties += "project.name" -> (name in paradox).value,
-    paradoxProperties += "project.version" -> (version in paradox).value,
-    paradoxProperties += "project.version.short" -> shortVersion((version in paradox).value),
-    paradoxProperties += "project.description" -> (description in paradox).value,
+    paradoxProperties ++= Map(
+      "project.name" -> (name in paradox).value,
+      "project.version" -> (version in paradox).value,
+      "project.version.short" -> shortVersion((version in paradox).value),
+      "project.description" -> (description in paradox).value,
+      "snip.root.base_dir" -> baseDirectory.value.toString),
     paradoxProperties ++= dateProperties,
     paradoxProperties ++= linkProperties(scalaVersion.value, apiURL.value, scmInfo.value),
 

--- a/plugin/src/sbt-test/paradox/snippets/build.sbt
+++ b/plugin/src/sbt-test/paradox/snippets/build.sbt
@@ -1,5 +1,8 @@
 lazy val docs = (project in file(".")).
   enablePlugins(ParadoxPlugin).
   settings(
-    paradoxTheme := None
+    paradoxTheme := None,
+    paradoxProperties in Compile ++= Map(
+      "snip.test.base_dir" -> (sourceDirectory in Test).value.toString,
+      "snip.test-scala.base_dir" -> "../../test/scala")
   )

--- a/plugin/src/sbt-test/paradox/snippets/expected/configured-bases.html
+++ b/plugin/src/sbt-test/paradox/snippets/expected/configured-bases.html
@@ -1,0 +1,4 @@
+<pre class="prettyprint"><code class="language-scala">val foo = 42</code></pre>
+<pre class="prettyprint"><code class="language-scala">val foo = 42</code></pre>
+<pre class="prettyprint"><code class="language-scala">val foo = 42</code></pre>
+<pre class="prettyprint"><code class="language-scala">val foo = 42</code></pre>

--- a/plugin/src/sbt-test/paradox/snippets/src/main/paradox/configured-bases.md
+++ b/plugin/src/sbt-test/paradox/snippets/src/main/paradox/configured-bases.md
@@ -1,0 +1,11 @@
+---
+snip.local.base_dir: ../../test/scala  
+---
+
+@@ snip [-]($test$/scala/Snippets.scala) { #foo }
+
+@@ snip [-]($test-scala$/Snippets.scala) { #foo }
+
+@@ snip [-]($root$/src/test/scala/Snippets.scala) { #foo }
+
+@@ snip [-]($local$/Snippets.scala) { #foo }

--- a/plugin/src/sbt-test/paradox/snippets/src/test/scala/Snippets.scala
+++ b/plugin/src/sbt-test/paradox/snippets/src/test/scala/Snippets.scala
@@ -20,4 +20,8 @@ object Snippets {
     }
     #config
     """
+
+  //#foo
+  val foo = 42
+  //#foo
 }

--- a/plugin/src/sbt-test/paradox/snippets/test
+++ b/plugin/src/sbt-test/paradox/snippets/test
@@ -5,3 +5,4 @@ $ must-mirror target/paradox/site/reference.html expected/reference.html
 $ must-mirror target/paradox/site/multiple.html expected/multiple.html
 $ must-mirror target/paradox/site/some-xml.html expected/some-xml.html
 $ must-mirror target/paradox/site/nocode.html expected/nocode.html
+$ must-mirror target/paradox/site/configured-bases.html expected/configured-bases.html


### PR DESCRIPTION
Time has shown that the simple `snippet.base_dir` support that came in with https://github.com/lightbend/paradox/pull/39/commits/9afc38fe3624f3904cd238e1adb1d2cace63a910 isn't quite sufficient for my use-case (and likely others as well).

For example, I'd like to refer to files in the `test` branch of my `doc` project as well as actual library code in the main project sources. In order to do this in a DRY and concise fashion this patch adds support for defining placeholders for snippet base directories that can be easily referred to where required.