### PR TITLE
Provide ability to disable prettify code highlighting

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/markdown/StyledVerbatim.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/StyledVerbatim.scala
@@ -65,5 +65,8 @@ abstract class StyledVerbatimSerializer extends VerbatimSerializer {
  */
 object PrettifyVerbatimSerializer extends StyledVerbatimSerializer {
   override def printPreAttributes(printer: Printer): Unit = printClass(printer, "prettyprint")
-  override def printCodeAttributes(printer: Printer, nodeType: String): Unit = printClass(printer, s"language-$nodeType")
+  override def printCodeAttributes(printer: Printer, nodeType: String): Unit = nodeType match {
+    case "text" | "nocode" => printClass(printer, "nocode")
+    case _                 => printClass(printer, s"language-$nodeType")
+  }
 }

--- a/docs/src/main/paradox/features/snippet-inclusion.md
+++ b/docs/src/main/paradox/features/snippet-inclusion.md
@@ -39,6 +39,14 @@ This will be rendered like this:
 
 ![multi_snip](../img/multi_snip.png)
 
+By default, Paradox uses Prettify to highlight code and will try to detect the
+language of the snippet if it is not explicitly provided. In cases where a
+snippet should not be highlighted use:
+
+```markdown
+@@snip [example.log](example.log) { #example-log type=text }
+```
+
 ### snippet.base_dir
 
 In order to specify your snippet source paths off a certain base directory you can define a snippet.base_dir property either in the page's front matter or globally like this (for example):

--- a/notes/0.2.7.markdown
+++ b/notes/0.2.7.markdown
@@ -1,6 +1,8 @@
 ### Enhancements
 
 - Add `@javadoc` parameterized link directive. [#43][43] by [@jonas][@jonas]
+- Provide ability to disable prettify code highlighting [#64][64] by [@jonas][@jonas]
 
   [43]: https://github.com/lightbend/paradox/issues/43
+  [64]: https://github.com/lightbend/paradox/issues/64
   [@jonas]: https://github.com/jonas

--- a/plugin/src/sbt-test/paradox/snippets/expected/nocode.html
+++ b/plugin/src/sbt-test/paradox/snippets/expected/nocode.html
@@ -1,0 +1,44 @@
+<pre class="prettyprint"><code class="nocode">certpath: -Using checker7 ... [sun.security.provider.certpath.RevocationChecker]
+certpath: connecting to OCSP service at: http://gtssl2-ocsp.geotrust.com
+certpath: OCSP response status: SUCCESSFUL
+certpath: OCSP response type: basic
+certpath: Responder&#39;s name: CN=GeoTrust SSL CA - G2 OCSP Responder, O=GeoTrust Inc., C=US
+certpath: OCSP response produced at: Wed Mar 19 13:57:32 PDT 2014
+certpath: OCSP number of SingleResponses: 1
+certpath: OCSP response cert #1: CN=GeoTrust SSL CA - G2 OCSP Responder, O=GeoTrust Inc., C=US
+certpath: Status of certificate (with serial number 159761413677206476752317239691621661939) is: GOOD
+certpath: Responder&#39;s certificate includes the extension id-pkix-ocsp-nocheck.
+certpath: OCSP response is signed by an Authorized Responder
+certpath: Verified signature of OCSP Response
+certpath: Response&#39;s validity interval is from Wed Mar 19 13:57:32 PDT 2014 until Wed Mar 26 13:57:32 PDT 2014
+certpath: -checker7 validation succeeded</code></pre>
+<pre class="prettyprint"><code class="nocode">certpath: -Using checker7 ... [sun.security.provider.certpath.RevocationChecker]
+certpath: connecting to OCSP service at: http://gtssl2-ocsp.geotrust.com
+certpath: OCSP response status: SUCCESSFUL
+certpath: OCSP response type: basic
+certpath: Responder&#39;s name: CN=GeoTrust SSL CA - G2 OCSP Responder, O=GeoTrust Inc., C=US
+certpath: OCSP response produced at: Wed Mar 19 13:57:32 PDT 2014
+certpath: OCSP number of SingleResponses: 1
+certpath: OCSP response cert #1: CN=GeoTrust SSL CA - G2 OCSP Responder, O=GeoTrust Inc., C=US
+certpath: Status of certificate (with serial number 159761413677206476752317239691621661939) is: GOOD
+certpath: Responder&#39;s certificate includes the extension id-pkix-ocsp-nocheck.
+certpath: OCSP response is signed by an Authorized Responder
+certpath: Verified signature of OCSP Response
+certpath: Response&#39;s validity interval is from Wed Mar 19 13:57:32 PDT 2014 until Wed Mar 26 13:57:32 PDT 2014
+certpath: -checker7 validation succeeded
+</code></pre>
+<pre class="prettyprint"><code class="nocode">certpath: -Using checker7 ... [sun.security.provider.certpath.RevocationChecker]
+certpath: connecting to OCSP service at: http://gtssl2-ocsp.geotrust.com
+certpath: OCSP response status: SUCCESSFUL
+certpath: OCSP response type: basic
+certpath: Responder&#39;s name: CN=GeoTrust SSL CA - G2 OCSP Responder, O=GeoTrust Inc., C=US
+certpath: OCSP response produced at: Wed Mar 19 13:57:32 PDT 2014
+certpath: OCSP number of SingleResponses: 1
+certpath: OCSP response cert #1: CN=GeoTrust SSL CA - G2 OCSP Responder, O=GeoTrust Inc., C=US
+certpath: Status of certificate (with serial number 159761413677206476752317239691621661939) is: GOOD
+certpath: Responder&#39;s certificate includes the extension id-pkix-ocsp-nocheck.
+certpath: OCSP response is signed by an Authorized Responder
+certpath: Verified signature of OCSP Response
+certpath: Response&#39;s validity interval is from Wed Mar 19 13:57:32 PDT 2014 until Wed Mar 26 13:57:32 PDT 2014
+certpath: -checker7 validation succeeded
+</code></pre>

--- a/plugin/src/sbt-test/paradox/snippets/src/main/paradox/nocode.md
+++ b/plugin/src/sbt-test/paradox/snippets/src/main/paradox/nocode.md
@@ -1,0 +1,35 @@
+@@ snip [no code](../../test/resources/certpath.log) { type=text }
+
+```text
+certpath: -Using checker7 ... [sun.security.provider.certpath.RevocationChecker]
+certpath: connecting to OCSP service at: http://gtssl2-ocsp.geotrust.com
+certpath: OCSP response status: SUCCESSFUL
+certpath: OCSP response type: basic
+certpath: Responder's name: CN=GeoTrust SSL CA - G2 OCSP Responder, O=GeoTrust Inc., C=US
+certpath: OCSP response produced at: Wed Mar 19 13:57:32 PDT 2014
+certpath: OCSP number of SingleResponses: 1
+certpath: OCSP response cert #1: CN=GeoTrust SSL CA - G2 OCSP Responder, O=GeoTrust Inc., C=US
+certpath: Status of certificate (with serial number 159761413677206476752317239691621661939) is: GOOD
+certpath: Responder's certificate includes the extension id-pkix-ocsp-nocheck.
+certpath: OCSP response is signed by an Authorized Responder
+certpath: Verified signature of OCSP Response
+certpath: Response's validity interval is from Wed Mar 19 13:57:32 PDT 2014 until Wed Mar 26 13:57:32 PDT 2014
+certpath: -checker7 validation succeeded
+```
+
+```nocode
+certpath: -Using checker7 ... [sun.security.provider.certpath.RevocationChecker]
+certpath: connecting to OCSP service at: http://gtssl2-ocsp.geotrust.com
+certpath: OCSP response status: SUCCESSFUL
+certpath: OCSP response type: basic
+certpath: Responder's name: CN=GeoTrust SSL CA - G2 OCSP Responder, O=GeoTrust Inc., C=US
+certpath: OCSP response produced at: Wed Mar 19 13:57:32 PDT 2014
+certpath: OCSP number of SingleResponses: 1
+certpath: OCSP response cert #1: CN=GeoTrust SSL CA - G2 OCSP Responder, O=GeoTrust Inc., C=US
+certpath: Status of certificate (with serial number 159761413677206476752317239691621661939) is: GOOD
+certpath: Responder's certificate includes the extension id-pkix-ocsp-nocheck.
+certpath: OCSP response is signed by an Authorized Responder
+certpath: Verified signature of OCSP Response
+certpath: Response's validity interval is from Wed Mar 19 13:57:32 PDT 2014 until Wed Mar 26 13:57:32 PDT 2014
+certpath: -checker7 validation succeeded
+```

--- a/plugin/src/sbt-test/paradox/snippets/src/test/resources/certpath.log
+++ b/plugin/src/sbt-test/paradox/snippets/src/test/resources/certpath.log
@@ -1,0 +1,14 @@
+certpath: -Using checker7 ... [sun.security.provider.certpath.RevocationChecker]
+certpath: connecting to OCSP service at: http://gtssl2-ocsp.geotrust.com
+certpath: OCSP response status: SUCCESSFUL
+certpath: OCSP response type: basic
+certpath: Responder's name: CN=GeoTrust SSL CA - G2 OCSP Responder, O=GeoTrust Inc., C=US
+certpath: OCSP response produced at: Wed Mar 19 13:57:32 PDT 2014
+certpath: OCSP number of SingleResponses: 1
+certpath: OCSP response cert #1: CN=GeoTrust SSL CA - G2 OCSP Responder, O=GeoTrust Inc., C=US
+certpath: Status of certificate (with serial number 159761413677206476752317239691621661939) is: GOOD
+certpath: Responder's certificate includes the extension id-pkix-ocsp-nocheck.
+certpath: OCSP response is signed by an Authorized Responder
+certpath: Verified signature of OCSP Response
+certpath: Response's validity interval is from Wed Mar 19 13:57:32 PDT 2014 until Wed Mar 26 13:57:32 PDT 2014
+certpath: -checker7 validation succeeded

--- a/plugin/src/sbt-test/paradox/snippets/test
+++ b/plugin/src/sbt-test/paradox/snippets/test
@@ -4,3 +4,4 @@ $ must-mirror target/paradox/site/snippets.html expected/snippets.html
 $ must-mirror target/paradox/site/reference.html expected/reference.html
 $ must-mirror target/paradox/site/multiple.html expected/multiple.html
 $ must-mirror target/paradox/site/some-xml.html expected/some-xml.html
+$ must-mirror target/paradox/site/nocode.html expected/nocode.html


### PR DESCRIPTION
Either using:

    ```nocode
    ...
    ```

or for snippets:

    @@ snip [apache.log](apache.log) { type=nocode }

---

As discussed in typesafehub/ssl-config#51 Paradox will eagerly highlight anything inside fenched code block. This PR provides an escape hatch for this behaviour.