### PR TITLE
Provide url to Github origin markdown files, resolve

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -305,7 +305,7 @@ case class SourceMarkdownDirective(page: Page, variables: Map[String, String])
   val ProjectUrl = """(.*github.com/[^/]+/[^/]+).*""".r
 
   val baseUrl = PropertyUrl("github.base_url", variables.get)
-  val paradoxDir = PropertyDirectory("github.markdown_dir", variables.get)
+  val paradoxDir = PropertyDirectory("github.paradox_dir", variables.get)
 
   def resolveLink(link: String, relativePath: jPath): Url = baseUrl.collect {
     case TreeUrl(url)    => url + paradoxDir.normalize(link, relativePath)

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Url.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Url.scala
@@ -89,7 +89,7 @@ case class PropertyDirectory(property: String, variables: String => Option[Strin
 
   private def convertToOsSeparator(path: String): String = {
     if (File.separator == "\\")
-      URLEncoder.encode(path.replace("/", File.separator), "UTF-8")
+      new URI(URLEncoder.encode(path, "UTF-8")).getPath
     else
       path
   }

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Url.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Url.scala
@@ -16,7 +16,7 @@
 
 package com.lightbend.paradox.markdown
 
-import java.net.{ URI, URISyntaxException }
+import java.net.{ URI, URISyntaxException, URLEncoder }
 import java.nio.file.{ Path => jPath }
 import java.io.File
 
@@ -83,8 +83,15 @@ case class PropertyDirectory(property: String, variables: String => Option[Strin
 
   def normalize(link: String, sourcePath: jPath): String = {
     val additionalLink = convertLink(link, sourcePath)
-    Url.parse(("/" + PropertyDirectory(property, variables).resolve.toString + "/src/main/paradox/" + additionalLink).replace("/", File.separator),
+    Url.parse(convertToOsSeparator("/" + PropertyDirectory(property, variables).resolve.toString + "/src/main/paradox/" + additionalLink),
       s"link [$additionalLink] contains an invalid URL").toString
+  }
+
+  private def convertToOsSeparator(path: String): String = {
+    if (File.separator == "\\")
+      URLEncoder.encode(path.replace("/", File.separator), "UTF-8")
+    else
+      path
   }
 
   private def convertLink(link: String, sourcePath: jPath, extensionExpected: String = ".md"): String = link match {

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Url.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Url.scala
@@ -82,6 +82,8 @@ case class PropertyDirectory(property: String, variables: String => Option[Strin
 
   def normalize(link: String, sourcePath: jPath): String = {
     val additionalLink = convertLink(link, sourcePath)
+    val normalizeVal = "/" + PropertyDirectory(property, variables).resolve.toString + "/src/main/paradox/" + additionalLink
+    println("--- Url: normalize = " + normalizeVal)
     Url.parse("/" + PropertyDirectory(property, variables).resolve.toString + "/src/main/paradox/" + additionalLink,
       s"link [$additionalLink] contains an invalid URL").toString
   }
@@ -89,11 +91,17 @@ case class PropertyDirectory(property: String, variables: String => Option[Strin
   private def convertLink(link: String, sourcePath: jPath, extensionExpected: String = ".md"): String = link match {
     case ""                                    => sourcePath.toString
     case l if (!l.endsWith(extensionExpected)) => throw Url.Error(s"[$l] is not a markdown (.md) file")
-    case l                                     => withoutLeaf(sourcePath.toString) + "/" + checkSeparatorDuplicates(normalizeLink(link))
+    case l =>
+      val finalLink = withoutLeaf(sourcePath.toString) + checkSeparatorDuplicates(normalizeLink(link))
+      println("--- Url: finalLink = " + finalLink)
+      return finalLink
   }
 
   private def withoutLeaf(path: String, separator: String = "/"): String = {
-    path.split(separator).reverse.tail.reverse.mkString(separator)
+    path.split(separator).reverse.tail.reverse.mkString(separator) match {
+      case "" => ""
+      case p  => p + "/"
+    }
   }
 
   private def checkSeparatorDuplicates(normalizedPath: String, separator: String = "/"): String = {

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Url.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Url.scala
@@ -17,6 +17,7 @@
 package com.lightbend.paradox.markdown
 
 import java.net.{ URI, URISyntaxException }
+import java.nio.file.{ Path => jPath }
 
 /**
  * Small wrapper around URI to help update individual components.
@@ -26,13 +27,14 @@ case class Url(base: URI) {
     case path if path.endsWith("/index.html") => this
     case path                                 => copy(path = path + "/")
   }
-  def /(path: String): Url = copy(path = base.getPath + "/" + path)
+  def /(path: String): Url = copy(path = base.getPath + (if (path != "") "/" + path else ""))
   def withQuery(query: String): Url = copy(query = query)
   def withFragment(fragment: String): Url = copy(fragment = fragment)
   def copy(path: String = base.getPath, query: String = base.getQuery, fragment: String = base.getFragment) = {
     val uri = new URI(base.getScheme, base.getUserInfo, base.getHost, base.getPort, path, query, fragment)
     Url(uri.normalize)
   }
+  override def toString(): String = base.toString
 }
 
 object Url {
@@ -53,8 +55,8 @@ object Url {
   }
 }
 
-case class PropertyUrl(property: String, variables: String => Option[String]) {
-  def base = variables(property) match {
+class BasePropertyClass(property: String, variables: String => Option[String]) {
+  def base: String = variables(property) match {
     case Some(baseUrl) => baseUrl
     case None          => throw Url.Error(s"property [$property] is not defined")
   }
@@ -62,10 +64,58 @@ case class PropertyUrl(property: String, variables: String => Option[String]) {
   def resolve(): Url = {
     Url.parse(base, s"property [$property] contains an invalid URL")
   }
+}
 
+case class PropertyUrl(property: String, variables: String => Option[String]) extends BasePropertyClass(property, variables) {
   def format(args: String*) = Url(base.format(args: _*))
 
   def collect(f: PartialFunction[String, String]): Url = {
     PropertyUrl(property, variables(_).collect(f)).resolve
+  }
+}
+
+case class PropertyDirectory(property: String, variables: String => Option[String]) extends BasePropertyClass(property, variables) {
+  override def base: String = variables(property) match {
+    case Some(baseUrl) => checkSeparatorDuplicates(normalizeBase(baseUrl))
+    case None          => throw Url.Error(s"property [$property] is not defined")
+  }
+
+  def normalize(link: String, sourcePath: jPath): String = {
+    val additionalLink = convertLink(link, sourcePath)
+    Url.parse("/" + PropertyDirectory(property, variables).resolve.toString + "/src/main/paradox/" + additionalLink,
+      s"link [$additionalLink] contains an invalid URL").toString
+  }
+
+  private def convertLink(link: String, sourcePath: jPath, extensionExpected: String = ".md"): String = link match {
+    case ""                                    => sourcePath.toString
+    case l if (!l.endsWith(extensionExpected)) => throw Url.Error(s"[$l] is not a markdown (.md) file")
+    case l                                     => withoutLeaf(sourcePath.toString) + "/" + checkSeparatorDuplicates(normalizeLink(link))
+  }
+
+  private def withoutLeaf(path: String, separator: String = "/"): String = {
+    path.split(separator).reverse.tail.reverse.mkString(separator)
+  }
+
+  private def checkSeparatorDuplicates(normalizedPath: String, separator: String = "/"): String = {
+    normalizedPath.split(separator).contains("") match {
+      case true  => throw Url.Error(s"[$normalizedPath] contains duplicate '/' separators")
+      case false => normalizedPath
+    }
+  }
+
+  private def normalizeBase(baseUrl: String): String = {
+    (baseUrl.startsWith("/"), baseUrl.endsWith("/")) match {
+      case (true, true)  => baseUrl.drop(1).dropRight(1)
+      case (true, false) => baseUrl.drop(1)
+      case (false, true) => baseUrl.dropRight(1)
+      case _             => baseUrl
+    }
+  }
+
+  private def normalizeLink(link: String): String = {
+    link.startsWith("/") match {
+      case true  => link.drop(1)
+      case false => link
+    }
   }
 }

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Url.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Url.scala
@@ -18,6 +18,7 @@ package com.lightbend.paradox.markdown
 
 import java.net.{ URI, URISyntaxException }
 import java.nio.file.{ Path => jPath }
+import java.io.File
 
 /**
  * Small wrapper around URI to help update individual components.
@@ -82,19 +83,14 @@ case class PropertyDirectory(property: String, variables: String => Option[Strin
 
   def normalize(link: String, sourcePath: jPath): String = {
     val additionalLink = convertLink(link, sourcePath)
-    val normalizeVal = "/" + PropertyDirectory(property, variables).resolve.toString + "/src/main/paradox/" + additionalLink
-    println("--- Url: normalize = " + normalizeVal)
-    Url.parse("/" + PropertyDirectory(property, variables).resolve.toString + "/src/main/paradox/" + additionalLink,
+    Url.parse(("/" + PropertyDirectory(property, variables).resolve.toString + "/src/main/paradox/" + additionalLink).replace("/", File.separator),
       s"link [$additionalLink] contains an invalid URL").toString
   }
 
   private def convertLink(link: String, sourcePath: jPath, extensionExpected: String = ".md"): String = link match {
     case ""                                    => sourcePath.toString
     case l if (!l.endsWith(extensionExpected)) => throw Url.Error(s"[$l] is not a markdown (.md) file")
-    case l =>
-      val finalLink = withoutLeaf(sourcePath.toString) + checkSeparatorDuplicates(normalizeLink(link))
-      println("--- Url: finalLink = " + finalLink)
-      return finalLink
+    case l                                     => withoutLeaf(sourcePath.toString) + checkSeparatorDuplicates(normalizeLink(link))
   }
 
   private def withoutLeaf(path: String, separator: String = "/"): String = {

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
@@ -112,6 +112,7 @@ object Writer {
     ScaladocDirective(context.location.tree.label, context.properties),
     JavadocDirective(context.location.tree.label, context.properties),
     GitHubDirective(context.location.tree.label, context.properties),
+    SourceMarkdownDirective(context.location.tree.label, context.properties),
     SnipDirective(context.location.tree.label, context.properties),
     FiddleDirective(context.location.tree.label),
     TocDirective(context.location),

--- a/core/src/test/scala/com/lightbend/paradox/markdown/FrontinSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/FrontinSpec.scala
@@ -86,7 +86,7 @@ class FrontinSpec extends MarkdownBaseSpec {
     f3.delete()
   }
 
-  it should "return the corresponding properties at 'out' filed instantiation, but can return an empty String as the body" in {
+  it should "return the corresponding properties at 'out' field instantiation, but can return an empty String as the body" in {
     Frontin(f4).header shouldEqual Map("out" -> "index.html")
     Frontin(f4).body shouldEqual
       prepare("""

--- a/core/src/test/scala/com/lightbend/paradox/markdown/MarkdownBaseSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/MarkdownBaseSpec.scala
@@ -27,8 +27,8 @@ abstract class MarkdownBaseSpec extends FlatSpec with Matchers {
   val markdownReader = new Reader
   val markdownWriter = new Writer
 
-  def markdown(text: String)(implicit context: Location[Page] => Writer.Context = writerContext): String = {
-    markdownPages("test.md" -> text).getOrElse("test.html", "")
+  def markdown(text: String, pagePath: String = "test.md")(implicit context: Location[Page] => Writer.Context = writerContext): String = {
+    markdownPages(pagePath -> text).getOrElse(pagePath.dropRight(".md".length) + ".html", "")
   }
 
   def markdownPages(mappings: (String, String)*)(implicit context: Location[Page] => Writer.Context = writerContext): Map[String, String] = {

--- a/core/src/test/scala/com/lightbend/paradox/markdown/SourceMarkdownDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/SourceMarkdownDirectiveSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.paradox.markdown
+
+class SourceMarkdownDirectiveSpec extends MarkdownBaseSpec {
+  implicit val context = writerContextWithProperties(
+    "github.base_url" -> "https://github.com/playframework/play-rest-api",
+    "github.markdown_dir" -> "docs")
+
+  "SourceMarkdown Directive" should "create links with configured base URL and markdown directory on github" in {
+    markdown("@source[link]()") shouldEqual
+      html("""<p><a href="https://github.com/playframework/play-rest-api/tree/master/docs/src/main/paradox/test.md">link</a></p>""")
+  }
+
+  it should "support 'source:' as an alternative name" in {
+    markdown("@source:[link]()") shouldEqual
+      html("""<p><a href="https://github.com/playframework/play-rest-api/tree/master/docs/src/main/paradox/test.md">link</a></p>""")
+  }
+
+  it should "display markdown source url of the file specified in parameter" in {
+    markdown("@source[link](index.md)") shouldEqual
+      html("""<p><a href="https://github.com/playframework/play-rest-api/tree/master/docs/src/main/paradox/index.md">link</a></p>""")
+  }
+
+  it should "display correct url for 'in-directory' files" in {
+    markdown("@source[link](some/index.md)") shouldEqual
+      html("""<p><a href="https://github.com/playframework/play-rest-api/tree/master/docs/src/main/paradox/some/index.md">link</a></p>""")
+  }
+
+  it should "display correct url for relative path to other files" in {
+    markdown("@source[link](../test.md)", "some/directory/index.md") shouldEqual
+      html("""<p><a href="https://github.com/playframework/play-rest-api/tree/master/docs/src/main/paradox/some/test.md">link</a></p>""")
+  }
+
+  it should "throw an error if github.markdown_dir contains '/' duplicates" in {
+    val duplicateSeparatorsContext = writerContextWithProperties(
+      "github.base_url" -> "https://github.com/playframework/play-rest-api",
+      "github.markdown_dir" -> "docs//dir")
+
+    the[ExternalLinkDirective.LinkException] thrownBy {
+      markdown("@source[link]()")(duplicateSeparatorsContext)
+    } should have message "Failed to resolve [] referenced from [test.html] because [docs//dir] contains duplicate '/' separators"
+  }
+
+  it should "throw an error if the link contains '/' duplicates" in {
+    the[ExternalLinkDirective.LinkException] thrownBy {
+      markdown("@source[link](some//link.md)")
+    } should have message "Failed to resolve [some//link.md] referenced from [test.html] because [some//link.md] contains duplicate '/' separators"
+  }
+
+  it should "throw an error if the link does not correspond to a markdown file" in {
+    the[ExternalLinkDirective.LinkException] thrownBy {
+      markdown("@source[link](some/link.mdi)")
+    } should have message "Failed to resolve [some/link.mdi] referenced from [test.html] because [some/link.mdi] is not a markdown (.md) file"
+  }
+
+  it should "throw an error if the link can't be converted into URL" in {
+    the[ExternalLinkDirective.LinkException] thrownBy {
+      markdown("@source[link](some/dir\\index.md)")
+    } should have message "Failed to resolve [some/dir\\index.md] referenced from [test.html] because link [/some/dir\\index.md] contains an invalid URL [/docs/src/main/paradox//some/dir\\index.md]"
+  }
+}

--- a/core/src/test/scala/com/lightbend/paradox/markdown/SourceMarkdownDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/SourceMarkdownDirectiveSpec.scala
@@ -46,7 +46,7 @@ class SourceMarkdownDirectiveSpec extends MarkdownBaseSpec {
       html("""<p><a href="https://github.com/lightbend/paradox/tree/v0.2.1/docs/manual/src/main/paradox/some/test.md">link</a></p>""")
   }
 
-  it should "throw an error if github.markdown_dir contains '/' duplicates" in {
+  it should "throw an error if github.paradox_dir contains '/' duplicates" in {
     val duplicateSeparatorsContext = writerContextWithProperties(
       "github.base_url" -> "https://github.com/lightbend/paradox/tree/v0.2.1",
       "github.paradox_dir" -> "docs//dir")
@@ -71,6 +71,6 @@ class SourceMarkdownDirectiveSpec extends MarkdownBaseSpec {
   it should "throw an error if the link can't be converted into URL" in {
     the[ExternalLinkDirective.LinkException] thrownBy {
       markdown("@source[link](some/dir\\index.md)")
-    } should have message "Failed to resolve [some/dir\\index.md] referenced from [test.html] because link [/some/dir\\index.md] contains an invalid URL [/docs/manual/src/main/paradox//some/dir\\index.md]"
+    } should have message "Failed to resolve [some/dir\\index.md] referenced from [test.html] because link [some/dir\\index.md] contains an invalid URL [/docs/manual/src/main/paradox/some/dir\\index.md]"
   }
 }

--- a/core/src/test/scala/com/lightbend/paradox/markdown/SourceMarkdownDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/SourceMarkdownDirectiveSpec.scala
@@ -70,7 +70,7 @@ class SourceMarkdownDirectiveSpec extends MarkdownBaseSpec {
 
   it should "throw an error if the link can't be converted into URL" in {
     the[ExternalLinkDirective.LinkException] thrownBy {
-      markdown("@source[link](some/dir\\index.md)")
-    } should have message "Failed to resolve [some/dir\\index.md] referenced from [test.html] because link [some/dir\\index.md] contains an invalid URL [/docs/manual/src/main/paradox/some/dir\\index.md]"
+      markdown("@source[link](some/dir|index.md)")
+    } should have message "Failed to resolve [some/dir|index.md] referenced from [test.html] because link [some/dir|index.md] contains an invalid URL [/docs/manual/src/main/paradox/some/dir|index.md]"
   }
 }

--- a/core/src/test/scala/com/lightbend/paradox/markdown/SourceMarkdownDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/SourceMarkdownDirectiveSpec.scala
@@ -18,37 +18,37 @@ package com.lightbend.paradox.markdown
 
 class SourceMarkdownDirectiveSpec extends MarkdownBaseSpec {
   implicit val context = writerContextWithProperties(
-    "github.base_url" -> "https://github.com/playframework/play-rest-api",
-    "github.markdown_dir" -> "docs")
+    "github.base_url" -> "https://github.com/lightbend/paradox/tree/v0.2.1",
+    "github.markdown_dir" -> "docs/manual")
 
   "SourceMarkdown Directive" should "create links with configured base URL and markdown directory on github" in {
     markdown("@source[link]()") shouldEqual
-      html("""<p><a href="https://github.com/playframework/play-rest-api/tree/master/docs/src/main/paradox/test.md">link</a></p>""")
+      html("""<p><a href="https://github.com/lightbend/paradox/tree/v0.2.1/docs/manual/src/main/paradox/test.md">link</a></p>""")
   }
 
   it should "support 'source:' as an alternative name" in {
     markdown("@source:[link]()") shouldEqual
-      html("""<p><a href="https://github.com/playframework/play-rest-api/tree/master/docs/src/main/paradox/test.md">link</a></p>""")
+      html("""<p><a href="https://github.com/lightbend/paradox/tree/v0.2.1/docs/manual/src/main/paradox/test.md">link</a></p>""")
   }
 
   it should "display markdown source url of the file specified in parameter" in {
     markdown("@source[link](index.md)") shouldEqual
-      html("""<p><a href="https://github.com/playframework/play-rest-api/tree/master/docs/src/main/paradox/index.md">link</a></p>""")
+      html("""<p><a href="https://github.com/lightbend/paradox/tree/v0.2.1/docs/manual/src/main/paradox/index.md">link</a></p>""")
   }
 
   it should "display correct url for 'in-directory' files" in {
     markdown("@source[link](some/index.md)") shouldEqual
-      html("""<p><a href="https://github.com/playframework/play-rest-api/tree/master/docs/src/main/paradox/some/index.md">link</a></p>""")
+      html("""<p><a href="https://github.com/lightbend/paradox/tree/v0.2.1/docs/manual/src/main/paradox/some/index.md">link</a></p>""")
   }
 
   it should "display correct url for relative path to other files" in {
     markdown("@source[link](../test.md)", "some/directory/index.md") shouldEqual
-      html("""<p><a href="https://github.com/playframework/play-rest-api/tree/master/docs/src/main/paradox/some/test.md">link</a></p>""")
+      html("""<p><a href="https://github.com/lightbend/paradox/tree/v0.2.1/docs/manual/src/main/paradox/some/test.md">link</a></p>""")
   }
 
   it should "throw an error if github.markdown_dir contains '/' duplicates" in {
     val duplicateSeparatorsContext = writerContextWithProperties(
-      "github.base_url" -> "https://github.com/playframework/play-rest-api",
+      "github.base_url" -> "https://github.com/lightbend/paradox/tree/v0.2.1",
       "github.markdown_dir" -> "docs//dir")
 
     the[ExternalLinkDirective.LinkException] thrownBy {
@@ -71,6 +71,6 @@ class SourceMarkdownDirectiveSpec extends MarkdownBaseSpec {
   it should "throw an error if the link can't be converted into URL" in {
     the[ExternalLinkDirective.LinkException] thrownBy {
       markdown("@source[link](some/dir\\index.md)")
-    } should have message "Failed to resolve [some/dir\\index.md] referenced from [test.html] because link [/some/dir\\index.md] contains an invalid URL [/docs/src/main/paradox//some/dir\\index.md]"
+    } should have message "Failed to resolve [some/dir\\index.md] referenced from [test.html] because link [/some/dir\\index.md] contains an invalid URL [/docs/manual/src/main/paradox//some/dir\\index.md]"
   }
 }

--- a/core/src/test/scala/com/lightbend/paradox/markdown/SourceMarkdownDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/SourceMarkdownDirectiveSpec.scala
@@ -19,7 +19,7 @@ package com.lightbend.paradox.markdown
 class SourceMarkdownDirectiveSpec extends MarkdownBaseSpec {
   implicit val context = writerContextWithProperties(
     "github.base_url" -> "https://github.com/lightbend/paradox/tree/v0.2.1",
-    "github.markdown_dir" -> "docs/manual")
+    "github.paradox_dir" -> "docs/manual")
 
   "SourceMarkdown Directive" should "create links with configured base URL and markdown directory on github" in {
     markdown("@source[link]()") shouldEqual
@@ -49,7 +49,7 @@ class SourceMarkdownDirectiveSpec extends MarkdownBaseSpec {
   it should "throw an error if github.markdown_dir contains '/' duplicates" in {
     val duplicateSeparatorsContext = writerContextWithProperties(
       "github.base_url" -> "https://github.com/lightbend/paradox/tree/v0.2.1",
-      "github.markdown_dir" -> "docs//dir")
+      "github.paradox_dir" -> "docs//dir")
 
     the[ExternalLinkDirective.LinkException] thrownBy {
       markdown("@source[link]()")(duplicateSeparatorsContext)

--- a/docs/src/main/paradox/features/linking.md
+++ b/docs/src/main/paradox/features/linking.md
@@ -21,6 +21,7 @@ directives are configured via base URLs defined in `paradoxProperties`:
 ```sbt
 paradoxProperties in Compile ++= Map(
   "github.base_url" -> s"https://github.com/lightbend/paradox/tree/${version.value}",
+  "github.paradox_dir" -> "docs",
   "scaladoc.akka.base_url" -> s"http://doc.akka.io/api/${Dependencies.akkaVersion}",
   "extref.rfc.base_url" -> "http://tools.ietf.org/html/rfc%s"
 )
@@ -101,6 +102,15 @@ If the sbt project's `scmInfo` setting is configured and the `browseUrl`
 points to a GitHub project, it is used as the GitHub base URL.
 
 [github-autolinking]: https://help.github.com/articles/autolinked-references-and-urls/
+
+#### @source directive
+
+Use the `@source` directive to link to corresponding markdown source files on GitHub.
+
+As in the previous section, the `github.base_url` property must be configured as well than the `github.paradox_dir` property which indicates the directory containing the paradox files (not the markdown files!), which are `build.sbt` and `src/main/paradox` files.
+
+To display the source link of a file on GitHub, use its path relative to the current file.
+For example, if the current file is `some/dir/index.md`, we could display a source link of `some/other.md` by writing `@source[link](../other.md)`. To display the source link of the current file, either use the common way `@source[link](index.md)` or simply `@source[link]()`.
 
 #### @extref directive
 


### PR DESCRIPTION
Resolve #57 

Setup:
- Set `github.base_dir` to select the github repo.
- Set `github.paradox_dir` to select the directory corresponding to paradox (src/main/paradox and build.sbt)

How:
- To display the source link of the current file: `@source[link]()`
- To display the source link of another file, use relative path: `@source[link](../index.md)`