### PR TITLE
Source url

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
+++ b/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
@@ -20,7 +20,6 @@ import com.lightbend.paradox.markdown.{ Breadcrumbs, Page, Path, Reader, TableOf
 import com.lightbend.paradox.template.{ CachedTemplates, PageTemplate }
 import com.lightbend.paradox.tree.Tree.{ Forest, Location }
 import java.io.File
-import java.nio.file.{ Path => jPath }
 import org.pegdown.ast.{ ActiveLinkNode, ExpLinkNode, RootNode }
 import org.stringtemplate.v4.STErrorListener
 import scala.annotation.tailrec

--- a/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
+++ b/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
@@ -16,7 +16,7 @@
 
 package com.lightbend.paradox
 
-import com.lightbend.paradox.markdown.{ Breadcrumbs, Page, Path, Reader, TableOfContents, Writer, Frontin, PropertyUrl }
+import com.lightbend.paradox.markdown.{ Breadcrumbs, Page, Path, Reader, TableOfContents, Writer, Frontin, Url, PropertyUrl }
 import com.lightbend.paradox.template.{ CachedTemplates, PageTemplate }
 import com.lightbend.paradox.tree.Tree.{ Forest, Location }
 import java.io.File
@@ -125,7 +125,11 @@ class ParadoxProcessor(reader: Reader = new Reader, writer: Writer = new Writer)
    * Github links, rendered to just a HTML for the link.
    */
   case class GithubLink(location: Option[Location[Page]], page: Page, writer: Writer, context: Writer.Context) extends PageTemplate.Link {
-    lazy val getHref: String = buildPath(PropertyUrl("github.base_url", context.properties.get).base, "/tree/master", page.relativePath)
+    lazy val getHref: String = try {
+      buildPath(PropertyUrl("github.base_url", context.properties.get).base, "/tree/master", page.relativePath)
+    } catch {
+      case e: Url.Error => null
+    }
     lazy val getHtml: String = getHref // TODO: temporary, should provide a link directly
     lazy val getTitle: String = "source"
     lazy val isActive: Boolean = false

--- a/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
+++ b/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
@@ -86,7 +86,7 @@ class ParadoxProcessor(reader: Reader = new Reader, writer: Writer = new Writer)
     lazy val getNavigation = writer.writeNavigation(pageToc.root(loc), context)
     lazy val hasSubheaders = page.headers.nonEmpty
     lazy val getToc = writer.writeToc(headerToc.headers(loc), context)
-    lazy val getSource_url = githubLink(Some(loc)).getHtml
+    lazy val getSourceUrl = githubLink(Some(loc)).getHtml
 
     lazy val getProperties = context.properties.asJava
 

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
@@ -59,11 +59,6 @@ case class Page(file: File, path: String, label: Node, h1: Header, headers: Fore
     }
     textNodes(label).mkString
   }
-
-  def relativePath: String = {
-    val currentPath = new File(".").getCanonicalFile.toPath
-    currentPath.relativize(file.toPath).toString
-  }
 }
 
 object Page {

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
@@ -59,6 +59,11 @@ case class Page(file: File, path: String, label: Node, h1: Header, headers: Fore
     }
     textNodes(label).mkString
   }
+
+  val relativePath: String = {
+    val currentPath = new File(".").getCanonicalFile.toPath
+    currentPath.relativize(file.toPath).toString
+  }
 }
 
 object Page {

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
@@ -60,7 +60,7 @@ case class Page(file: File, path: String, label: Node, h1: Header, headers: Fore
     textNodes(label).mkString
   }
 
-  val relativePath: String = {
+  def relativePath: String = {
     val currentPath = new File(".").getCanonicalFile.toPath
     currentPath.relativize(file.toPath).toString
   }

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Url.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Url.scala
@@ -33,6 +33,7 @@ case class Url(base: URI) {
     val uri = new URI(base.getScheme, base.getUserInfo, base.getHost, base.getPort, path, query, fragment)
     Url(uri.normalize)
   }
+  override def toString: String = base.toString
 }
 
 object Url {

--- a/core/src/main/scala/com/lightbend/paradox/template/PageTemplateSystem.scala
+++ b/core/src/main/scala/com/lightbend/paradox/template/PageTemplateSystem.scala
@@ -77,6 +77,7 @@ object PageTemplate {
     def getNavigation: String
     def hasSubheaders: Boolean
     def getToc: String
+    def getSource: String
     def getProperties: JMap[String, String]
   }
 

--- a/core/src/main/scala/com/lightbend/paradox/template/PageTemplateSystem.scala
+++ b/core/src/main/scala/com/lightbend/paradox/template/PageTemplateSystem.scala
@@ -77,7 +77,7 @@ object PageTemplate {
     def getNavigation: String
     def hasSubheaders: Boolean
     def getToc: String
-    def getSource_url: String
+    def getSourceUrl: String
     def getProperties: JMap[String, String]
   }
 

--- a/core/src/main/scala/com/lightbend/paradox/template/PageTemplateSystem.scala
+++ b/core/src/main/scala/com/lightbend/paradox/template/PageTemplateSystem.scala
@@ -77,7 +77,7 @@ object PageTemplate {
     def getNavigation: String
     def hasSubheaders: Boolean
     def getToc: String
-    def getSource: String
+    def getSource_url: String
     def getProperties: JMap[String, String]
   }
 

--- a/core/src/test/scala/com/lightbend/paradox/markdown/MarkdownBaseSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/MarkdownBaseSpec.scala
@@ -132,7 +132,7 @@ abstract class MarkdownBaseSpec extends FlatSpec with Matchers {
     lazy val getNavigation = ""
     lazy val hasSubheaders = false
     lazy val getToc = ""
-    lazy val getSource_url = ""
+    lazy val getSourceUrl = ""
 
     lazy val getProperties = properties.asJava
   }

--- a/core/src/test/scala/com/lightbend/paradox/markdown/MarkdownBaseSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/MarkdownBaseSpec.scala
@@ -132,7 +132,7 @@ abstract class MarkdownBaseSpec extends FlatSpec with Matchers {
     lazy val getNavigation = ""
     lazy val hasSubheaders = false
     lazy val getToc = ""
-    lazy val getSource = ""
+    lazy val getSource_url = ""
 
     lazy val getProperties = properties.asJava
   }

--- a/core/src/test/scala/com/lightbend/paradox/markdown/MarkdownBaseSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/MarkdownBaseSpec.scala
@@ -132,6 +132,7 @@ abstract class MarkdownBaseSpec extends FlatSpec with Matchers {
     lazy val getNavigation = ""
     lazy val hasSubheaders = false
     lazy val getToc = ""
+    lazy val getSource = ""
 
     lazy val getProperties = properties.asJava
   }

--- a/docs/src/main/paradox/features/templating.md
+++ b/docs/src/main/paradox/features/templating.md
@@ -24,7 +24,7 @@ Here is a list of supported properties that can be used in the string template f
 - `$page.navigation$` : gives the links of all pages in the project (except the main page).
 - `$page.subheaders$` : determines if the current page contains subheaders or not, which concretely means that it contains multiple sections depending on the `toc-.
 - `$page.toc$` : in relation with `$page.subheaders$`, displays the list of all sections on the page as anchor links.
-- `$page.source$` : contains the plain text of the github source url of the current page. Works only if the associated `github.base_url` is defined (see @ref[github directive](linking.md#github-directive) for additional information)
+- `$page.source$` : contains the plain text of the github source url of the current page. Works only if the associated `github.base_url` is defined (see @ref[github directive](linking.md#github-directive) for additional information). If this property is not defined, this field returns a null value; then a condition testing like `$if(page.source)$` would be necessary in this case.
 - `$page.properties$`: displays purely the list of the properties for the current page, which contains the actual properties of the page and the global ones shared to all pages. See next sections to figure out how to deal with properties.
 
 ### Custom properties

--- a/docs/src/main/paradox/features/templating.md
+++ b/docs/src/main/paradox/features/templating.md
@@ -24,7 +24,7 @@ Here is a list of supported properties that can be used in the string template f
 - `$page.navigation$` : gives the links of all pages in the project (except the main page).
 - `$page.subheaders$` : determines if the current page contains subheaders or not, which concretely means that it contains multiple sections depending on the `toc-.
 - `$page.toc$` : in relation with `$page.subheaders$`, displays the list of all sections on the page as anchor links.
-- `$page.source_url$` : contains the plain text of the github source url of the current page. Works only if the associated `github.base_url` is defined (see @ref[github directive](linking.md#github-directive) for additional information). If this property is not defined, this field returns a null value; then a condition testing like `$if(page.source_url)$` would be necessary in this case.
+- `$page.sourceUrl$` : contains the plain text of the github source url of the current page. Works only if the associated `github.base_url` is defined (see @ref[github directive](linking.md#github-directive) for additional information). If this property is not defined, this field returns a null value; then a condition testing like `$if(page.sourceUrl)$` would be necessary in this case.
 - `$page.properties$`: displays purely the list of the properties for the current page, which contains the actual properties of the page and the global ones shared to all pages. See next sections to figure out how to deal with properties.
 
 ### Custom properties

--- a/docs/src/main/paradox/features/templating.md
+++ b/docs/src/main/paradox/features/templating.md
@@ -24,6 +24,7 @@ Here is a list of supported properties that can be used in the string template f
 - `$page.navigation$` : gives the links of all pages in the project (except the main page).
 - `$page.subheaders$` : determines if the current page contains subheaders or not, which concretely means that it contains multiple sections depending on the `toc-.
 - `$page.toc$` : in relation with `$page.subheaders$`, displays the list of all sections on the page as anchor links.
+- `$page.source$` : contains the plain text of the github source url of the current page. Works only if the associated `github.base_url` is defined (see @ref[github directive](linking.md#github-directive) for additional information)
 - `$page.properties$`: displays purely the list of the properties for the current page, which contains the actual properties of the page and the global ones shared to all pages. See next sections to figure out how to deal with properties.
 
 ### Custom properties

--- a/docs/src/main/paradox/features/templating.md
+++ b/docs/src/main/paradox/features/templating.md
@@ -24,7 +24,7 @@ Here is a list of supported properties that can be used in the string template f
 - `$page.navigation$` : gives the links of all pages in the project (except the main page).
 - `$page.subheaders$` : determines if the current page contains subheaders or not, which concretely means that it contains multiple sections depending on the `toc-.
 - `$page.toc$` : in relation with `$page.subheaders$`, displays the list of all sections on the page as anchor links.
-- `$page.source$` : contains the plain text of the github source url of the current page. Works only if the associated `github.base_url` is defined (see @ref[github directive](linking.md#github-directive) for additional information). If this property is not defined, this field returns a null value; then a condition testing like `$if(page.source)$` would be necessary in this case.
+- `$page.source_url$` : contains the plain text of the github source url of the current page. Works only if the associated `github.base_url` is defined (see @ref[github directive](linking.md#github-directive) for additional information). If this property is not defined, this field returns a null value; then a condition testing like `$if(page.source_url)$` would be necessary in this case.
 - `$page.properties$`: displays purely the list of the properties for the current page, which contains the actual properties of the page and the global ones shared to all pages. See next sections to figure out how to deal with properties.
 
 ### Custom properties

--- a/notes/0.2.8.markdown
+++ b/notes/0.2.8.markdown
@@ -4,7 +4,7 @@
 
 ### Source origin url on GitHub
 
-`$page.source_url$` contains the plain text of the github source url of the current page. Works only if the associated `github.base_url` is defined. If it doesn't, this field returns a null value; then a condition testing like `$if(page.source_url)$` would be necessary in this case.
+`$page.sourceUrl$` contains the plain text of the github source url of the current page. Works only if the associated `github.base_url` is defined. If it doesn't, this field returns a null value; then a condition testing like `$if(page.sourceUrl)$` would be necessary in this case.
 Provide a new template "sourc.st" available in the generic theme which allows to display a simple plain text with the link associated to the current file.
 
 [69]: https://github.com/lightbend/paradox/pull/69

--- a/notes/0.2.8.markdown
+++ b/notes/0.2.8.markdown
@@ -1,0 +1,10 @@
+### Fixes and enhancements
+
+- Source url. See below. [#69][69] by [@jonas][@jonas] and [@gsechaud][@gsechaud]
+
+### Source origin url on GitHub
+
+`$page.source_url$` contains the plain text of the github source url of the current page. Works only if the associated `github.base_url` is defined. If it doesn't, this field returns a null value; then a condition testing like `$if(page.source_url)$` would be necessary in this case.
+Provide a new template "sourc.st" available in the generic theme which allows to display a simple plain text with the link associated to the current file.
+
+[69]: https://github.com/lightbend/paradox/pull/69

--- a/themes/generic/src/main/assets/css/page.css
+++ b/themes/generic/src/main/assets/css/page.css
@@ -927,3 +927,14 @@ small {
 
 .site-footer-base .logo:hover .svg-icon-logo-image {
 }
+
+.source-github {
+  padding: 10px;
+  padding-top: 30px;
+  margin-top: 20px;
+  border-top: 1px solid #cccccc;
+}
+
+.source-github a {
+  font-weight: bold;
+}

--- a/themes/generic/src/main/assets/page.st
+++ b/themes/generic/src/main/assets/page.st
@@ -64,6 +64,7 @@ $endif$
 <div class="page-content row">
 <div class="small-12 large-9 column" id="docs">
 $page.content$
+$source()$
 $if(page.next.html)$
 <div class="nav-next">
 <p><strong>Next:</strong> $page.next.html$</p>

--- a/themes/generic/src/main/assets/source.st
+++ b/themes/generic/src/main/assets/source.st
@@ -1,0 +1,1 @@
+<div class="source-github">The source code for this page can be found <a href="$page.source$">here</a>.</div>

--- a/themes/generic/src/main/assets/source.st
+++ b/themes/generic/src/main/assets/source.st
@@ -1,5 +1,5 @@
-$if(page.source_url)$
+$if(page.sourceUrl)$
 <div class="source-github">
-The source code for this page can be found <a href="$page.source_url$">here</a>.
+The source code for this page can be found <a href="$page.sourceUrl$">here</a>.
 </div>
 $endif$

--- a/themes/generic/src/main/assets/source.st
+++ b/themes/generic/src/main/assets/source.st
@@ -1,1 +1,7 @@
-<div class="source-github">The source code for this page can be found <a href="$page.source$">here</a>.</div>
+<div class="source-github">
+$if(page.source)$
+The source code for this page can be found <a href="$page.source$">here</a>.
+$else$
+No associated source code found for this page.
+$endif$
+</div>

--- a/themes/generic/src/main/assets/source.st
+++ b/themes/generic/src/main/assets/source.st
@@ -1,7 +1,5 @@
+$if(page.source_url)$
 <div class="source-github">
-$if(page.source)$
-The source code for this page can be found <a href="$page.source$">here</a>.
-$else$
-No associated source code found for this page.
-$endif$
+The source code for this page can be found <a href="$page.source_url$">here</a>.
 </div>
+$endif$


### PR DESCRIPTION
In relation with #68 
Resolve #57 

Create a template "source.st" containing the pieces of text necessary to display the github source url of the current markdown file:
- If `github.base_url` is defined in the build: displays "The source code for this page can be found here." (link for "here")
- Otherwise: displays "No associated source code found for this page."