### PR TITLE
Fix the scaladoc directive to work for Scala 2.12

### DIFF
--- a/notes/0.2.8.markdown
+++ b/notes/0.2.8.markdown
@@ -1,10 +1,14 @@
 ### Fixes and enhancements
 
 - Source url. See below. [#69][69] by [@jonas][@jonas] and [@gsechaud][@gsechaud]
+- Fix `@scaladoc` to work for Scala 2.12. [#77][77] by [@jonas][@jonas]
 
 ### Source origin url on GitHub
 
 `$page.source_url$` contains the plain text of the github source url of the current page. Works only if the associated `github.base_url` is defined. If it doesn't, this field returns a null value; then a condition testing like `$if(page.source_url)$` would be necessary in this case.
-Provide a new template "sourc.st" available in the generic theme which allows to display a simple plain text with the link associated to the current file.
+Provide a new template "source.st" available in the generic theme which allows to display a simple plain text with the link associated to the current file.
 
-[69]: https://github.com/lightbend/paradox/pull/69
+  [69]: https://github.com/lightbend/paradox/pull/69
+  [77]: https://github.com/lightbend/paradox/pull/77
+  [@gsechaud]: https://github.com/gsechaud
+  [@jonas]: https://github.com/jonas

--- a/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
+++ b/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
@@ -164,11 +164,11 @@ object ParadoxPlugin extends AutoPlugin {
       "javadoc.java.base_url" -> sys.props.get("java.specification.version").collect {
         case JavaSpecVersion(v) => url(s"https://docs.oracle.com/javase/$v/docs/api/")
       },
-      "scaladoc.version" -> scalaVersion,
+      "scaladoc.version" -> Some(scalaVersion),
       "scaladoc.scala.base_url" -> Some(url(s"http://www.scala-lang.org/api/$scalaVersion")),
       "scaladoc.base_url" -> apiURL,
       "github.base_url" -> scmInfo.map(_.browseUrl).filter(_.getHost == "github.com")
-    ).collect { case (prop, Some(url)) => (prop, url.toString) }
+    ).collect { case (prop, Some(value)) => (prop, value.toString) }
   }
 
   def readProperty(resource: String, property: String): String = {

--- a/plugin/src/sbt-test/paradox/scaladoc-2.12/build.sbt
+++ b/plugin/src/sbt-test/paradox/scaladoc-2.12/build.sbt
@@ -1,0 +1,12 @@
+val akkaVersion = "2.4.13"
+val akkaHttpVersion = "10.0.0"
+
+version := "0.1.0"
+scalaVersion := "2.12.1"
+
+enablePlugins(ParadoxPlugin)
+paradoxTheme := None
+paradoxProperties in Compile ++= Map(
+  "scaladoc.akka.base_url" -> s"http://doc.akka.io/api/akka/$akkaVersion",
+  "scaladoc.akka.http.base_url" -> s"http://doc.akka.io/api/akka-http/$akkaHttpVersion"
+)

--- a/plugin/src/sbt-test/paradox/scaladoc-2.12/expected/scaladoc-2.12.html
+++ b/plugin/src/sbt-test/paradox/scaladoc-2.12/expected/scaladoc-2.12.html
@@ -1,0 +1,2 @@
+<p>Use a <a href="http://www.scala-lang.org/api/2.12.1/scala/concurrent/Future.html">Future</a> to avoid that long running operations block the <a href="http://doc.akka.io/api/akka/2.4.13/akka/actor/Actor.html">Actor</a>.</p>
+<p><a href="http://doc.akka.io/api/akka-http/10.0.0/akka/http/scaladsl/Http$.html">Http</a></p>

--- a/plugin/src/sbt-test/paradox/scaladoc-2.12/project/plugins.sbt
+++ b/plugin/src/sbt-test/paradox/scaladoc-2.12/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % sys.props("project.version"))

--- a/plugin/src/sbt-test/paradox/scaladoc-2.12/src/main/paradox/_template/page.st
+++ b/plugin/src/sbt-test/paradox/scaladoc-2.12/src/main/paradox/_template/page.st
@@ -1,0 +1,1 @@
+$page.content$

--- a/plugin/src/sbt-test/paradox/scaladoc-2.12/src/main/paradox/scaladoc-2.12.md
+++ b/plugin/src/sbt-test/paradox/scaladoc-2.12/src/main/paradox/scaladoc-2.12.md
@@ -1,0 +1,3 @@
+Use a @scaladoc:[Future](scala.concurrent.Future) to avoid that long running operations block the @scaladoc:[Actor](akka.actor.Actor).
+
+@scaladoc:[Http](akka.http.scaladsl.Http$)

--- a/plugin/src/sbt-test/paradox/scaladoc-2.12/test
+++ b/plugin/src/sbt-test/paradox/scaladoc-2.12/test
@@ -1,0 +1,3 @@
+> paradox
+
+$ must-mirror target/paradox/site/scaladoc-2.12.html expected/scaladoc-2.12.html


### PR DESCRIPTION
As discovered in https://github.com/akka/akka-http/pull/626#discussion_r91309519 the `scaladoc.version` property used by the `@scaladoc` directive to support Scala 2.12 didn't get propagated.