### PR TITLE
fix extref docs

### DIFF
--- a/docs/src/main/paradox/features/linking.md
+++ b/docs/src/main/paradox/features/linking.md
@@ -109,7 +109,9 @@ URL templates can be configured via `extref.<scheme>.base_url` and the
 template may contain one `%s` which is replaced with the scheme specific
 part of the link URL. For example, given the property:
 
-    scaladoc.rfc.base_url=http://tools.ietf.org/html/rfc%s
+```text
+extref.rfc.base_url=http://tools.ietf.org/html/rfc%s
+```
 
 then `@extref[RFC 2119](rfc:2119)` will resolve to the URL
 <http://tools.ietf.org/html/rfc2119>.


### PR DESCRIPTION
- s/scaladoc/extref https://github.com/lightbend/paradox/blob/3546b7534/plugin/src/sbt-test/paradox/parameterized-links/build.sbt#L10
- use "text" syntax highlight. "//" is not comment in this case


## before

![before](https://cloud.githubusercontent.com/assets/389787/21353070/b03977b0-c707-11e6-842e-5c6074b482fb.png)


## after

![after](https://cloud.githubusercontent.com/assets/389787/21353088/c9a5a00c-c707-11e6-9b29-a0df1bfe548b.png)
