### PR TITLE
Deprecate `@var[foo]` directive in favor of `$foo$`

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/markdown/Reader.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Reader.scala
@@ -28,13 +28,11 @@ import scala.concurrent.duration._
 class Reader(parser: Parser) {
 
   def this(options: Int = Extensions.ALL ^ Extensions.HARDWRAPS /* disable hard wraps, see #31 */ ,
-           directiveMarker: Char = ParserWithDirectives.DEFAULT_DIRECTIVE_MARKER,
            maxParsingTime: Duration = 2.seconds,
            parseRunnerProvider: Parser.ParseRunnerProvider = Parser.DefaultParseRunnerProvider,
            plugins: PegDownPlugins = PegDownPlugins.NONE) =
     this(Parboiled.createParser[ParserWithDirectives, AnyRef](
       classOf[ParserWithDirectives],
-      directiveMarker: java.lang.Character,
       options: java.lang.Integer,
       maxParsingTime.toMillis: java.lang.Long,
       parseRunnerProvider,

--- a/core/src/test/scala/com/lightbend/paradox/markdown/VarDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/VarDirectiveSpec.scala
@@ -26,36 +26,45 @@ class VarDirectiveSpec extends MarkdownBaseSpec {
     writerContext(loc).copy(properties = testProperties)
   }
 
-  "Var directive" should "insert property values" in {
-    markdown("@var[version]") shouldEqual html("<p>1.2.3</p>")
-  }
-
-  it should "support 'var:' as an alternative name" in {
-    markdown("@var:[version]") shouldEqual html("<p>1.2.3</p>")
+  "Var substitution" should "insert property values" in {
+    markdown("$version$") shouldEqual html("<p>1.2.3</p>")
   }
 
   it should "work within markdown inlines" in {
-    markdown("Version is *@var[version]*.") shouldEqual html("<p>Version is <em>1.2.3</em>.</p>")
+    markdown("Version is *$version$*.") shouldEqual html("<p>Version is <em>1.2.3</em>.</p>")
   }
 
   it should "work within markdown blocks" in {
-    markdown("- @var[version]") shouldEqual html("<ul><li>1.2.3</li></ul>")
+    markdown("- $version$") shouldEqual html("<ul><li>1.2.3</li></ul>")
   }
 
   it should "work within link labels" in {
-    markdown("[Version @var[version]](version.html)") shouldEqual html("""<p><a href="version.html">Version 1.2.3</a></p>""")
+    markdown("[Version $version$](version.html)") shouldEqual html("""<p><a href="version.html">Version 1.2.3</a></p>""")
   }
 
   it should "work within other inline directives" in {
-    markdown("@ref:[Version @var[version]](test.md)") shouldEqual html("""<p><a href="test.html">Version 1.2.3</a></p>""")
+    markdown("@ref:[Version $version$](test.md)") shouldEqual html("""<p><a href="test.html">Version 1.2.3</a></p>""")
   }
 
   it should "retain whitespace before and after" in {
-    markdown("The @var[version] version.") shouldEqual html("<p>The 1.2.3 version.</p>")
+    markdown("The $version$ version.") shouldEqual html("<p>The 1.2.3 version.</p>")
   }
 
-  it should "parse but ignore directive source and attributes" in {
+  it should "support escaping the $ delimiter" in {
+    markdown("The \\$version$ version.") shouldEqual html("<p>The $version$ version.</p>")
+    markdown("The \\$version\\$ ver.$s$.ion.") shouldEqual html("<p>The $version$ ver.&lt;s&gt;.ion.</p>")
+    markdown("The $ver\\$ion$ version.") shouldEqual html("<p>The &lt;ver$ion&gt; version.</p>")
+  }
+
+  it should "support the legacy @var directive notation" in {
+    markdown("@var[version]") shouldEqual html("<p>1.2.3</p>")
+  }
+
+  it should "support the legacy 'var:' alternative name" in {
+    markdown("@var:[version]") shouldEqual html("<p>1.2.3</p>")
+  }
+
+  it should "parse but ignore legacy directive source and attributes" in {
     markdown("The @var[version] (xxx) { .var a=1 } version.") shouldEqual html("<p>The 1.2.3 version.</p>")
   }
-
 }

--- a/docs/src/main/paradox/features/snippet-inclusion.md
+++ b/docs/src/main/paradox/features/snippet-inclusion.md
@@ -58,20 +58,31 @@ should not be highlighted set `type=text` in the directive's attribute section:
 @@snip [example.log](example.log) { #example-log type=text }
 ```
 
-### snippet.base_dir
+### snip.*.base_dir
 
-In order to specify your snippet source paths off a certain base directory you can define a snippet.base_dir property either in the page's front matter or globally like this (for example):
+In order to specify your snippet source paths off certain base directories you can define placeholders
+either in the page's front matter or globally like this (for example):
 
 ```sbt
 paradoxProperties in Compile ++= Map(
-  "snippet.base_dir" -> s"${(sourceDirectory in Test).value}/scala/org/example"
+  "snip.foo.base_dir" -> "../../../some/dir",
+  "snip.test.base_dir" -> s"${(sourceDirectory in Test).value}/scala/org/example"
 )
 ```
 
-You can then refer to this snippet base directory by starting a snippet path with .../, e.g.
+You can then refer to one of the defined base directories by starting the snippet's target path with `$placeholder$`,
+for example:
 
 ```markdown
-@@snip [Hello.scala](.../Hello.scala) { #hello_example }
+@@snip [Hello.scala]($foo$/Hello.scala) { #hello_example }
+
+@@snip [Yeah.scala]($test$/Yeah.scala) { #yeah_example }
+
+@@snip [Yeah.scala]($root$/src/test/scala/org/example/Yeah.scala) { #yeah_example }
 ```
 
-**Note**: Using this feature will not allow GitHub to preview the images correctly on the web.
+If a placeholder directory is relative (like `$foo$` in this example) it'll be based of the path of the respective page
+it is used in. Also, *paradox* always auto-defines the placeholder `$root$` to denote the absolute path of the
+SBT project's root directory.
+
+**Note**: Using this feature will not allow GitHub to follow the snippet links correctly on the web UI.

--- a/docs/src/main/paradox/features/templating.md
+++ b/docs/src/main/paradox/features/templating.md
@@ -31,8 +31,11 @@ Here is a list of supported properties that can be used in the string template f
 
 Properties are key-value pairs available in your pages. For a property named `foo`:
 
-- Inside template files, you can use `$page.properties.("foo")`, or `$foo$` if the template's name does not contain dots.
-- Inside markdown files, you can use either `@var[foo]` (or `@var:[foo]`) inline block, or in container block if you want to call properties inside @var[tripleDelimiters] delimiters using `@@@ vars` around the block and using `$foo$` to call the property.
+- Inside template files use `$page.properties.("foo")` or `$foo$` if the template's name does not contain dots.
+- Inside markdown files use either `$foo$` inline.
+- Inside markdown file container blocks delimited by @var[tripleDelimiters] use `@@@vars` around the block and `$foo$` to call the property.
+
+The special `$` character can always be escaped with a back slash, i.e. `\$`.
 
 To add properties to your pages, there exists two ways for doing this:
 

--- a/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
+++ b/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
@@ -56,10 +56,12 @@ object ParadoxPlugin extends AutoPlugin {
     version in paradox := version.value,
     description in paradox := description.value,
 
-    paradoxProperties += "project.name" -> (name in paradox).value,
-    paradoxProperties += "project.version" -> (version in paradox).value,
-    paradoxProperties += "project.version.short" -> shortVersion((version in paradox).value),
-    paradoxProperties += "project.description" -> (description in paradox).value,
+    paradoxProperties ++= Map(
+      "project.name" -> (name in paradox).value,
+      "project.version" -> (version in paradox).value,
+      "project.version.short" -> shortVersion((version in paradox).value),
+      "project.description" -> (description in paradox).value,
+      "snip.root.base_dir" -> baseDirectory.value.toString),
     paradoxProperties ++= dateProperties,
     paradoxProperties ++= linkProperties(scalaVersion.value, apiURL.value, scmInfo.value),
 

--- a/plugin/src/sbt-test/paradox/snippets/build.sbt
+++ b/plugin/src/sbt-test/paradox/snippets/build.sbt
@@ -1,5 +1,8 @@
 lazy val docs = (project in file(".")).
   enablePlugins(ParadoxPlugin).
   settings(
-    paradoxTheme := None
+    paradoxTheme := None,
+    paradoxProperties in Compile ++= Map(
+      "snip.test.base_dir" -> (sourceDirectory in Test).value.toString,
+      "snip.test-scala.base_dir" -> "../../test/scala")
   )

--- a/plugin/src/sbt-test/paradox/snippets/expected/configured-bases.html
+++ b/plugin/src/sbt-test/paradox/snippets/expected/configured-bases.html
@@ -1,0 +1,4 @@
+<pre class="prettyprint"><code class="language-scala">val foo = 42</code></pre>
+<pre class="prettyprint"><code class="language-scala">val foo = 42</code></pre>
+<pre class="prettyprint"><code class="language-scala">val foo = 42</code></pre>
+<pre class="prettyprint"><code class="language-scala">val foo = 42</code></pre>

--- a/plugin/src/sbt-test/paradox/snippets/src/main/paradox/configured-bases.md
+++ b/plugin/src/sbt-test/paradox/snippets/src/main/paradox/configured-bases.md
@@ -1,0 +1,11 @@
+---
+snip.local.base_dir: ../../test/scala  
+---
+
+@@ snip [-]($test$/scala/Snippets.scala) { #foo }
+
+@@ snip [-]($test-scala$/Snippets.scala) { #foo }
+
+@@ snip [-]($root$/src/test/scala/Snippets.scala) { #foo }
+
+@@ snip [-]($local$/Snippets.scala) { #foo }

--- a/plugin/src/sbt-test/paradox/snippets/src/test/scala/Snippets.scala
+++ b/plugin/src/sbt-test/paradox/snippets/src/test/scala/Snippets.scala
@@ -20,4 +20,8 @@ object Snippets {
     }
     #config
     """
+
+  //#foo
+  val foo = 42
+  //#foo
 }

--- a/plugin/src/sbt-test/paradox/snippets/test
+++ b/plugin/src/sbt-test/paradox/snippets/test
@@ -5,3 +5,4 @@ $ must-mirror target/paradox/site/reference.html expected/reference.html
 $ must-mirror target/paradox/site/multiple.html expected/multiple.html
 $ must-mirror target/paradox/site/some-xml.html expected/some-xml.html
 $ must-mirror target/paradox/site/nocode.html expected/nocode.html
+$ must-mirror target/paradox/site/configured-bases.html expected/configured-bases.html


### PR DESCRIPTION
(This PR builds on https://github.com/lightbend/paradox/pull/60, so please merge that one first!)

As discussed in https://github.com/lightbend/paradox/pull/60 this PR completes the unification of property substitution towards the StringTemplate `$foo$` notation.

In order to not break existing documentation the old way of using `@var[foo]` instead of `$foo$` still works but is not documented anymore.