### PR TITLE
Fix StringTemplate indent bug for snippets

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/template/PageTemplateSystem.scala
+++ b/core/src/main/scala/com/lightbend/paradox/template/PageTemplateSystem.scala
@@ -16,10 +16,10 @@
 
 package com.lightbend.paradox.template
 
-import java.io.File
+import java.io.{ File, OutputStreamWriter, FileOutputStream }
 import java.util.{ Map => JMap }
 import org.stringtemplate.v4.misc.STMessage
-import org.stringtemplate.v4.{ STErrorListener, STRawGroupDir, ST }
+import org.stringtemplate.v4.{ STErrorListener, STRawGroupDir, ST, NoIndentWriter }
 import collection.concurrent.TrieMap
 
 object CachedTemplates {
@@ -54,7 +54,10 @@ class PageTemplate(directory: File, name: String = PageTemplate.DefaultName, sta
         t.add("page", contents)
       case None => sys.error(s"StringTemplate '$name' was not found for '$target'. Create a template or set a theme that contains one.")
     }
-    template.write(target, errorListener)
+    val osWriter = new OutputStreamWriter(new FileOutputStream(target))
+    val noIndentWriter = new NoIndentWriter(osWriter)
+    template.write(noIndentWriter) // does not take into account the errorListener any more...
+    osWriter.close
     target
   }
 

--- a/plugin/src/sbt-test/paradox/snippet-noindent-writer/build.sbt
+++ b/plugin/src/sbt-test/paradox/snippet-noindent-writer/build.sbt
@@ -1,0 +1,6 @@
+lazy val root = (project in file(".")).
+  enablePlugins(ParadoxPlugin).
+  settings(
+    paradoxTheme := None,
+    name := "snippet-indent"
+  )

--- a/plugin/src/sbt-test/paradox/snippet-noindent-writer/expected/index.html
+++ b/plugin/src/sbt-test/paradox/snippet-noindent-writer/expected/index.html
@@ -1,0 +1,19 @@
+<div>
+<div>
+<pre class="prettyprint"><code class="language-scala">object Hello extends App {
+  def say(str: String): Unit = {
+    println(str)
+  }
+  
+  say(&quot;hello&quot;)
+}</code></pre>
+</div>
+</div>
+
+<pre class="prettyprint"><code class="language-scala">object Hello extends App {
+  def say(str: String): Unit = {
+    println(str)
+  }
+  
+  say(&quot;hello&quot;)
+}</code></pre>

--- a/plugin/src/sbt-test/paradox/snippet-noindent-writer/project/plugins.sbt
+++ b/plugin/src/sbt-test/paradox/snippet-noindent-writer/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % sys.props("project.version"))

--- a/plugin/src/sbt-test/paradox/snippet-noindent-writer/src/main/paradox/_template/page.st
+++ b/plugin/src/sbt-test/paradox/snippet-noindent-writer/src/main/paradox/_template/page.st
@@ -1,0 +1,7 @@
+<div>
+  <div>
+    $page.content$
+  </div>
+</div>
+
+$page.content$

--- a/plugin/src/sbt-test/paradox/snippet-noindent-writer/src/main/paradox/code-samples/Hello.scala
+++ b/plugin/src/sbt-test/paradox/snippet-noindent-writer/src/main/paradox/code-samples/Hello.scala
@@ -1,0 +1,9 @@
+// #hello_example
+object Hello extends App {
+  def say(str: String): Unit = {
+    println(str)
+  }
+  
+  say("hello")
+}
+// #hello_example

--- a/plugin/src/sbt-test/paradox/snippet-noindent-writer/src/main/paradox/index.md
+++ b/plugin/src/sbt-test/paradox/snippet-noindent-writer/src/main/paradox/index.md
@@ -1,0 +1,1 @@
+@@snip[Hello](code-samples/Hello.scala)

--- a/plugin/src/sbt-test/paradox/snippet-noindent-writer/test
+++ b/plugin/src/sbt-test/paradox/snippet-noindent-writer/test
@@ -1,0 +1,3 @@
+> paradox
+
+$ must-mirror target/paradox/site/main/index.html expected/index.html


### PR DESCRIPTION
Resolve #84 

Use the "NoIndentWriter" as a writer for each template

No matter how the theme is built (indentations or not), the generated html pages will be built in order to remove them.