### PR TITLE
Run verify on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,4 +16,4 @@ install:
 build_script:
   - sbt clean compile
 test_script:
-  - sbt test
+  - sbt verify


### PR DESCRIPTION
This brings the AppVeyor config in line with the changes in #87.

Specifically:

* Re-introduces running the scripted tests on Windows
* Adds testing that the paradox docs build successfully on Windows