### PR TITLE
fix char code.

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/markdown/Frontin.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Frontin.scala
@@ -28,7 +28,7 @@ object Frontin {
     (str.trim == separator) && (str startsWith separator)
 
   def apply(file: File): Frontin =
-    apply(scala.io.Source.fromFile(file).getLines.mkString("\n"))
+    apply(scala.io.Source.fromFile(file)("UTF-8").getLines.mkString("\n"))
 
   def apply(str: String): Frontin =
     str.linesWithSeparators.toList match {


### PR DESCRIPTION
- Set UTF-8 as the character code of the read file
- Compiling failed in Japanese Windows
  - ShiftJIS was automatically used
