### PR TITLE
Clean up headers, formatting, and warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/pegdown/ParserWithDirectives.java
+++ b/core/src/main/java/org/pegdown/ParserWithDirectives.java
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/java/org/pegdown/ParserWithDirectives.java
+++ b/core/src/main/java/org/pegdown/ParserWithDirectives.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/pegdown/ast/ActiveLinkNode.java
+++ b/core/src/main/java/org/pegdown/ast/ActiveLinkNode.java
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/java/org/pegdown/ast/ActiveLinkNode.java
+++ b/core/src/main/java/org/pegdown/ast/ActiveLinkNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/pegdown/ast/AnchorLinkSuperNode.java
+++ b/core/src/main/java/org/pegdown/ast/AnchorLinkSuperNode.java
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/java/org/pegdown/ast/AnchorLinkSuperNode.java
+++ b/core/src/main/java/org/pegdown/ast/AnchorLinkSuperNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/pegdown/ast/DirectiveAttributes.java
+++ b/core/src/main/java/org/pegdown/ast/DirectiveAttributes.java
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/java/org/pegdown/ast/DirectiveAttributes.java
+++ b/core/src/main/java/org/pegdown/ast/DirectiveAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/pegdown/ast/DirectiveNode.java
+++ b/core/src/main/java/org/pegdown/ast/DirectiveNode.java
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/java/org/pegdown/ast/DirectiveNode.java
+++ b/core/src/main/java/org/pegdown/ast/DirectiveNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
+++ b/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
+++ b/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
@@ -32,15 +32,16 @@ class ParadoxProcessor(reader: Reader = new Reader, writer: Writer = new Writer)
   /**
    * Process all mappings to build the site.
    */
-  def process(mappings: Seq[(File, String)],
-              leadingBreadcrumbs: List[(String, String)],
-              outputDirectory: File,
-              sourceSuffix: String,
-              targetSuffix: String,
-              properties: Map[String, String],
-              navigationDepth: Int,
-              themeDir: File,
-              errorListener: STErrorListener): Seq[(File, String)] = {
+  def process(
+    mappings:           Seq[(File, String)],
+    leadingBreadcrumbs: List[(String, String)],
+    outputDirectory:    File,
+    sourceSuffix:       String,
+    targetSuffix:       String,
+    properties:         Map[String, String],
+    navigationDepth:    Int,
+    themeDir:           File,
+    errorListener:      STErrorListener): Seq[(File, String)] = {
     val pages = parsePages(mappings, Path.replaceSuffix(sourceSuffix, targetSuffix))
     val paths = Page.allPaths(pages).toSet
     val globalPageMappings = rootPageMappings(pages)

--- a/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
+++ b/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/ActiveLink.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/ActiveLink.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/ActiveLink.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/ActiveLink.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/AnchorLink.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/AnchorLink.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/AnchorLink.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/AnchorLink.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Breadcrumbs.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Breadcrumbs.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Breadcrumbs.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Breadcrumbs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Frontin.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Frontin.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Frontin.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Frontin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Index.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Index.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Index.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Index.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Reader.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Reader.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Reader.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Reader.scala
@@ -27,10 +27,11 @@ import scala.concurrent.duration._
  */
 class Reader(parser: Parser) {
 
-  def this(options: Int = Extensions.ALL ^ Extensions.HARDWRAPS /* disable hard wraps, see #31 */ ,
-           maxParsingTime: Duration = 2.seconds,
-           parseRunnerProvider: Parser.ParseRunnerProvider = Parser.DefaultParseRunnerProvider,
-           plugins: PegDownPlugins = PegDownPlugins.NONE) =
+  def this(
+    options:             Int                        = Extensions.ALL ^ Extensions.HARDWRAPS /* disable hard wraps, see #31 */ ,
+    maxParsingTime:      Duration                   = 2.seconds,
+    parseRunnerProvider: Parser.ParseRunnerProvider = Parser.DefaultParseRunnerProvider,
+    plugins:             PegDownPlugins             = PegDownPlugins.NONE) =
     this(Parboiled.createParser[ParserWithDirectives, AnyRef](
       classOf[ParserWithDirectives],
       options: java.lang.Integer,

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Reader.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Reader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Snippet.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Snippet.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Snippet.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Snippet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/StyledVerbatim.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/StyledVerbatim.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/StyledVerbatim.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/StyledVerbatim.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/TableOfContents.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/TableOfContents.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/TableOfContents.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/TableOfContents.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Url.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Url.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Url.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Url.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
@@ -27,9 +27,10 @@ import scala.collection.JavaConverters._
  */
 class Writer(serializer: Writer.Context => ToHtmlSerializer) {
 
-  def this(linkRenderer: Writer.Context => LinkRenderer = Writer.defaultLinks,
-           verbatimSerializers: Map[String, VerbatimSerializer] = Writer.defaultVerbatims,
-           serializerPlugins: Writer.Context => Seq[ToHtmlSerializerPlugin] = Writer.defaultPlugins) =
+  def this(
+    linkRenderer:        Writer.Context => LinkRenderer                = Writer.defaultLinks,
+    verbatimSerializers: Map[String, VerbatimSerializer]               = Writer.defaultVerbatims,
+    serializerPlugins:   Writer.Context => Seq[ToHtmlSerializerPlugin] = Writer.defaultPlugins) =
     this((context: Writer.Context) => new ToHtmlSerializer(
       linkRenderer(context),
       verbatimSerializers.asJava,
@@ -86,12 +87,12 @@ object Writer {
    * Write context which is passed through to directives.
    */
   case class Context(
-    location: Location[Page],
-    paths: Set[String],
-    pageMappings: String => String = Path.replaceExtension(DefaultSourceSuffix, DefaultTargetSuffix),
-    sourceSuffix: String = DefaultSourceSuffix,
-    targetSuffix: String = DefaultTargetSuffix,
-    properties: Map[String, String] = Map.empty)
+    location:     Location[Page],
+    paths:        Set[String],
+    pageMappings: String => String    = Path.replaceExtension(DefaultSourceSuffix, DefaultTargetSuffix),
+    sourceSuffix: String              = DefaultSourceSuffix,
+    targetSuffix: String              = DefaultTargetSuffix,
+    properties:   Map[String, String] = Map.empty)
 
   def defaultLinks(context: Context): LinkRenderer =
     new DefaultLinkRenderer(context)

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/template/PageTemplateSystem.scala
+++ b/core/src/main/scala/com/lightbend/paradox/template/PageTemplateSystem.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/scala/com/lightbend/paradox/template/PageTemplateSystem.scala
+++ b/core/src/main/scala/com/lightbend/paradox/template/PageTemplateSystem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/tree/Tree.scala
+++ b/core/src/main/scala/com/lightbend/paradox/tree/Tree.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/scala/com/lightbend/paradox/tree/Tree.scala
+++ b/core/src/main/scala/com/lightbend/paradox/tree/Tree.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/AnchorLinkSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/AnchorLinkSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/AnchorLinkSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/AnchorLinkSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/CalloutDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/CalloutDirectiveSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/CalloutDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/CalloutDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/ExtRefDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/ExtRefDirectiveSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/ExtRefDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/ExtRefDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/FiddleDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/FiddleDirectiveSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/FiddleDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/FiddleDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/FrontinSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/FrontinSpec.scala
@@ -23,14 +23,16 @@ class FrontinSpec extends MarkdownBaseSpec {
   val second = "second line"
 
   val f1 = new File("f1.md")
-  writeInFile(f1,
+  writeInFile(
+    f1,
     """
     |%s
     |%s
     """ format (first, second))
 
   val f2 = new File("f2.md")
-  writeInFile(f2,
+  writeInFile(
+    f2,
     """
     |---
     |---
@@ -39,7 +41,8 @@ class FrontinSpec extends MarkdownBaseSpec {
     """ format (first, second))
 
   val f3 = new File("f3.md")
-  writeInFile(f3,
+  writeInFile(
+    f3,
     """
     |---
     |out: index.html
@@ -49,7 +52,8 @@ class FrontinSpec extends MarkdownBaseSpec {
     """ format (first, second))
 
   val f4 = new File("f4.md")
-  writeInFile(f4,
+  writeInFile(
+    f4,
     """
     |---
     |out: index.html

--- a/core/src/test/scala/com/lightbend/paradox/markdown/FrontinSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/FrontinSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/FrontinSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/FrontinSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/GitHubDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/GitHubDirectiveSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/GitHubDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/GitHubDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/IndexSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/IndexSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/IndexSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/IndexSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/JavadocDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/JavadocDirectiveSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/JavadocDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/JavadocDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/LayoutSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/LayoutSpec.scala
@@ -69,7 +69,8 @@ class LayoutSpec extends MarkdownBaseSpec {
       |#Foo
       |some text
       """
-    )("page.st" -> defaultTemplate,
+    )(
+        "page.st" -> defaultTemplate,
         "noPageRef.st" -> """
       |<div>
       |No page ref

--- a/core/src/test/scala/com/lightbend/paradox/markdown/LayoutSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/LayoutSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/LayoutSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/LayoutSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/MarkdownBaseSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/MarkdownBaseSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/MarkdownBaseSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/MarkdownBaseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/PagePropertiesSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/PagePropertiesSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/PagePropertiesSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/PagePropertiesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/PathSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/PathSpec.scala
@@ -21,7 +21,8 @@ import java.io.File
 
 class PathSpec extends FlatSpec with Matchers {
   def provideRelativeMapping: (Map[String, String], String) = {
-    val mappings = Map("index.md" -> "index.html",
+    val mappings = Map(
+      "index.md" -> "index.html",
       "a/A.md" -> "a/A.html",
       "b/B.md" -> "b/B.html",
       "a/a2/A2.md" -> "a/a2/A2.html",
@@ -88,7 +89,8 @@ class PathSpec extends FlatSpec with Matchers {
 
   "Path.relativeMapping" should "return the correct mapping given the current source file and the global Mappings" in {
     val (mappings, sourcePath) = provideRelativeMapping
-    Path.relativeMapping(sourcePath, mappings) shouldEqual Map("index.md" -> "../../index.html",
+    Path.relativeMapping(sourcePath, mappings) shouldEqual Map(
+      "index.md" -> "../../index.html",
       "a/A.md" -> "../A.html",
       "b/B.md" -> "../../b/B.html",
       "a/a2/A2.md" -> "../a2/A2.html",

--- a/core/src/test/scala/com/lightbend/paradox/markdown/PathSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/PathSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/PathSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/PathSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/PropertiesLoadSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/PropertiesLoadSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/PropertiesLoadSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/PropertiesLoadSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/RefDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/RefDirectiveSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/RefDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/RefDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/ScaladocDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/ScaladocDirectiveSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/ScaladocDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/ScaladocDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/TocDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/TocDirectiveSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/TocDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/TocDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/VarDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/VarDirectiveSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/VarDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/VarDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/VarsDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/VarsDirectiveSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/VarsDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/VarsDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/WrapDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/WrapDirectiveSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/test/scala/com/lightbend/paradox/markdown/WrapDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/WrapDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -46,7 +46,7 @@ which basically means that all of our extensions would start with `@` (for inlin
 
 ### License and credits
 
-- Copyright 2015-2016 Lightbend, Inc. Paradox is provided under the Apache 2.0 license.
+- Copyright 2015-2017 Lightbend, Inc. Paradox is provided under the Apache 2.0 license.
 - The markdown engine is based on Mathias's [Pegdown][].
 
 @@@ index

--- a/docs/src/main/scala/Hello.scala
+++ b/docs/src/main/scala/Hello.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/docs/src/main/scala/Hello.scala
+++ b/docs/src/main/scala/Hello.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxKeys.scala
+++ b/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxKeys.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxKeys.scala
+++ b/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxKeys.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
+++ b/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
@@ -79,8 +79,8 @@ object ParadoxPlugin extends AutoPlugin {
 
     includeFilter in paradoxMarkdownToHtml := "*.md",
     excludeFilter in paradoxMarkdownToHtml := HiddenFileFilter,
-    sources in paradoxMarkdownToHtml <<= Defaults.collectFiles(sourceDirectories in paradox, includeFilter in paradoxMarkdownToHtml, excludeFilter in paradoxMarkdownToHtml),
-    mappings in paradoxMarkdownToHtml <<= Defaults.relativeMappings(sources in paradoxMarkdownToHtml, sourceDirectories in paradox),
+    sources in paradoxMarkdownToHtml := Defaults.collectFiles(sourceDirectories in paradox, includeFilter in paradoxMarkdownToHtml, excludeFilter in paradoxMarkdownToHtml).value,
+    mappings in paradoxMarkdownToHtml := Defaults.relativeMappings(sources in paradoxMarkdownToHtml, sourceDirectories in paradox).value,
     target in paradoxMarkdownToHtml := target.value / "paradox" / "html",
 
     managedSourceDirectories in paradoxTheme := paradoxTheme.value.toSeq.map { theme =>
@@ -90,10 +90,10 @@ object ParadoxPlugin extends AutoPlugin {
     sourceDirectories in paradoxTheme := (managedSourceDirectories in paradoxTheme).value :+ (sourceDirectory in paradoxTheme).value,
     includeFilter in paradoxTheme := AllPassFilter,
     excludeFilter in paradoxTheme := HiddenFileFilter,
-    sources in paradoxTheme <<= Defaults.collectFiles(sourceDirectories in paradoxTheme, includeFilter in paradoxTheme, excludeFilter in paradoxTheme) dependsOn {
+    sources in paradoxTheme := (Defaults.collectFiles(sourceDirectories in paradoxTheme, includeFilter in paradoxTheme, excludeFilter in paradoxTheme) dependsOn {
       WebKeys.webJars in Assets // extract webjars first
-    },
-    mappings in paradoxTheme <<= Defaults.relativeMappings(sources in paradoxTheme, sourceDirectories in paradoxTheme),
+    }).value,
+    mappings in paradoxTheme := Defaults.relativeMappings(sources in paradoxTheme, sourceDirectories in paradoxTheme).value,
     // if there are duplicates, select the file from the local template to allow overrides/extensions in themes
     WebKeys.deduplicators in paradoxTheme += SbtWeb.selectFileFrom((sourceDirectory in paradoxTheme).value),
     mappings in paradoxTheme := SbtWeb.deduplicateMappings((mappings in paradoxTheme).value, (WebKeys.deduplicators in paradoxTheme).value),
@@ -112,10 +112,10 @@ object ParadoxPlugin extends AutoPlugin {
     sourceDirectories in paradoxTemplate := Seq((sourceDirectory in paradoxTemplate).value),
     includeFilter in paradoxTemplate := AllPassFilter,
     excludeFilter in paradoxTemplate := "*.st" || "*.stg",
-    sources in paradoxTemplate <<= Defaults.collectFiles(sourceDirectories in paradoxTemplate, includeFilter in paradoxTemplate, excludeFilter in paradoxTemplate) dependsOn {
+    sources in paradoxTemplate := (Defaults.collectFiles(sourceDirectories in paradoxTemplate, includeFilter in paradoxTemplate, excludeFilter in paradoxTemplate) dependsOn {
       paradoxThemeDirectory // trigger theme extraction first
-    },
-    mappings in paradoxTemplate <<= Defaults.relativeMappings(sources in paradoxTemplate, sourceDirectories in paradoxTemplate),
+    }).value,
+    mappings in paradoxTemplate := Defaults.relativeMappings(sources in paradoxTemplate, sourceDirectories in paradoxTemplate).value,
 
     paradoxMarkdownToHtml := {
       IO.delete((target in paradoxMarkdownToHtml).value)
@@ -137,8 +137,8 @@ object ParadoxPlugin extends AutoPlugin {
       // exclude markdown sources and the _template directory sources
       (includeFilter in paradoxMarkdownToHtml).value || InDirectoryFilter((sourceDirectory in paradoxTheme).value)
     },
-    sources in paradox <<= Defaults.collectFiles(sourceDirectories in paradox, includeFilter in paradox, excludeFilter in paradox),
-    mappings in paradox <<= Defaults.relativeMappings(sources in paradox, sourceDirectories in paradox),
+    sources in paradox := Defaults.collectFiles(sourceDirectories in paradox, includeFilter in paradox, excludeFilter in paradox).value,
+    mappings in paradox := Defaults.relativeMappings(sources in paradox, sourceDirectories in paradox).value,
     mappings in paradox ++= (mappings in paradoxTemplate).value,
     mappings in paradox ++= paradoxMarkdownToHtml.value,
     mappings in paradox ++= {

--- a/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
+++ b/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
+++ b/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -54,7 +54,7 @@ object Common extends AutoPlugin {
   val confHeader = header(before = None, prefix = "# ", after = None)
 
   def header(before: Option[String], prefix: String, after: Option[String]): String = {
-    val content = Seq("Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>",
+    val content = Seq("Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>",
       "",
       """Licensed under the Apache License, Version 2.0 (the "License");""",
       """you may not use this file except in compliance with the License.""",

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -17,7 +17,7 @@
 import sbt._
 import sbt.Keys._
 import de.heikoseeberger.sbtheader.{ HeaderPattern, HeaderPlugin, AutomateHeaderPlugin }
-import com.typesafe.sbt.SbtScalariform.{ scalariformSettings, ScalariformKeys }
+import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import scalariform.formatter.preferences._
 
 /**
@@ -30,7 +30,7 @@ object Common extends AutoPlugin {
   override def requires = plugins.JvmPlugin && HeaderPlugin
 
   // AutomateHeaderPlugin is not an allRequirements-AutoPlugin, so explicitly add settings here:
-  override def projectSettings = scalariformSettings ++ AutomateHeaderPlugin.projectSettings ++ Seq(
+  override def projectSettings = AutomateHeaderPlugin.projectSettings ++ Seq(
     scalacOptions ++= Seq("-encoding", "UTF-8", "-target:jvm-1.6", "-unchecked", "-deprecation", "-feature"),
     javacOptions ++= Seq("-encoding", "UTF-8", "-source", "1.6", "-target", "1.6"),
     // Scalariform settings
@@ -38,7 +38,7 @@ object Common extends AutoPlugin {
       .setPreference(AlignSingleLineCaseStatements, true)
       .setPreference(AlignSingleLineCaseStatements.MaxArrowIndent, 100)
       .setPreference(DoubleIndentClassDeclaration, true)
-      .setPreference(PreserveDanglingCloseParenthesis, true)
+      .setPreference(DanglingCloseParenthesis, Preserve)
       .setPreference(AlignParameters, true),
     // Header settings
     HeaderPlugin.autoImport.headers := Map(

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -50,8 +50,8 @@ object Common extends AutoPlugin {
 
   // Header text generation
 
-  val scalaOrJavaHeader = header(before = Some("/*"), prefix = " * ", after = Some(" */"))
-  val confHeader = header(before = None, prefix = "# ", after = None)
+  val scalaOrJavaHeader = header(before = Some("/*"), prefix = " *", after = Some(" */"))
+  val confHeader = header(before = None, prefix = "#", after = None)
 
   def header(before: Option[String], prefix: String, after: Option[String]): String = {
     val content = Seq("Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>",
@@ -67,6 +67,7 @@ object Common extends AutoPlugin {
       """WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.""",
       """See the License for the specific language governing permissions and""",
       """limitations under the License.""")
-    (before.toSeq ++ content.map(prefix.+) ++ after.toSeq).mkString("", "\n", "\n\n")
+    def addPrefix(line: String) = if (line.isEmpty) prefix else s"$prefix $line"
+    (before.toSeq ++ content.map(addPrefix) ++ after.toSeq).mkString("", "\n", "\n\n")
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,17 +15,13 @@
  */
 
 addSbtPlugin("com.github.gseitz"     % "sbt-release"     % "1.0.1")
-addSbtPlugin("com.typesafe.sbt"      % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform"       % "sbt-scalariform" % "1.6.0")
 addSbtPlugin("com.typesafe.tmp"      % "sbt-header"      % "1.5.0-JDK6-0.1")
 addSbtPlugin("me.lessis"             % "bintray-sbt"     % "0.3.0")
 addSbtPlugin("com.jsuereth"          % "sbt-pgp"         % "1.0.0")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox"     % "0.2.7")
 
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
-
-// override scalariform version to get some fixes
-resolvers += Resolver.typesafeRepo("releases")
-libraryDependencies += "org.scalariform" %% "scalariform" % "0.1.5-20140822-69e2e30"
 
 lazy val metaroot = (project in file(".")).
   dependsOn(metaThemePlugin)

--- a/theme-plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxThemePlugin.scala
+++ b/theme-plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxThemePlugin.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/theme-plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxThemePlugin.scala
+++ b/theme-plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxThemePlugin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2016 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Just upgrading and tidying up some things:

- update the header copyright year
- remove trailing whitespace from header generation
- upgrade to newer scalariform (to avoid errors on format)
- clean up sbt deprecation warnings