### PR TITLE
Remove global cache for templates to allow changes

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
+++ b/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
@@ -17,7 +17,7 @@
 package com.lightbend.paradox
 
 import com.lightbend.paradox.markdown.{ Breadcrumbs, Page, Path, Reader, TableOfContents, Writer, Frontin, PropertyUrl, Url }
-import com.lightbend.paradox.template.{ CachedTemplates, PageTemplate }
+import com.lightbend.paradox.template.PageTemplate
 import com.lightbend.paradox.tree.Tree.{ Forest, Location }
 import java.io.File
 import org.pegdown.ast.{ ActiveLinkNode, ExpLinkNode, RootNode }
@@ -40,7 +40,7 @@ class ParadoxProcessor(reader: Reader = new Reader, writer: Writer = new Writer)
     targetSuffix:       String,
     properties:         Map[String, String],
     navigationDepth:    Int,
-    themeDir:           File,
+    pageTemplate:       PageTemplate,
     errorListener:      STErrorListener): Seq[(File, String)] = {
     val pages = parsePages(mappings, Path.replaceSuffix(sourceSuffix, targetSuffix))
     val paths = Page.allPaths(pages).toSet
@@ -57,9 +57,8 @@ class ParadoxProcessor(reader: Reader = new Reader, writer: Writer = new Writer)
         val headerToc = new TableOfContents(pages = false, headers = true, ordered = false, maxDepth = navigationDepth)
         val pageContext = PageContents(leadingBreadcrumbs, loc, writer, writerContext, pageToc, headerToc)
         val outputFile = new File(outputDirectory, page.path)
-        val template = CachedTemplates(themeDir, page.properties(Page.Properties.DefaultLayoutMdIndicator, PageTemplate.DefaultName))
         outputFile.getParentFile.mkdirs
-        template.write(pageContext, outputFile, errorListener)
+        pageTemplate.write(page.properties(Page.Properties.DefaultLayoutMdIndicator, pageTemplate.defaultName), pageContext, outputFile, errorListener)
         render(loc.next, rendered :+ (outputFile, page.path))
       case None => rendered
     }

--- a/core/src/main/scala/com/lightbend/paradox/template/PageTemplate.scala
+++ b/core/src/main/scala/com/lightbend/paradox/template/PageTemplate.scala
@@ -22,30 +22,16 @@ import org.stringtemplate.v4.misc.STMessage
 import org.stringtemplate.v4.{ STErrorListener, STRawGroupDir, ST, NoIndentWriter }
 import collection.concurrent.TrieMap
 
-object CachedTemplates {
-  def apply(dir: File, templateName: String = PageTemplate.DefaultName): PageTemplate = {
-    cache.get((dir, templateName)) match {
-      case Some(t) => t
-      case _ =>
-        val newTemplate = new PageTemplate(dir, templateName)
-        cache((dir, templateName)) = newTemplate
-        newTemplate
-    }
-  }
-
-  val cache: TrieMap[(File, String), PageTemplate] = TrieMap()
-}
-
 /**
  * Page template writer.
  */
-class PageTemplate(directory: File, name: String = PageTemplate.DefaultName, startDelimiter: Char = '$', stopDelimiter: Char = '$') {
+class PageTemplate(directory: File, val defaultName: String = "page", startDelimiter: Char = '$', stopDelimiter: Char = '$') {
   private val templates = new STRawGroupDir(directory.getAbsolutePath, startDelimiter, stopDelimiter)
 
   /**
    * Write a templated page to the target file.
    */
-  def write(contents: PageTemplate.Contents, target: File, errorListener: STErrorListener): File = {
+  def write(name: String, contents: PageTemplate.Contents, target: File, errorListener: STErrorListener): File = {
     import scala.collection.JavaConverters._
 
     val template = Option(templates.getInstanceOf(name)) match {
@@ -64,8 +50,6 @@ class PageTemplate(directory: File, name: String = PageTemplate.DefaultName, sta
 }
 
 object PageTemplate {
-  val DefaultName = "page"
-
   /**
    * All page information to give to the template.
    */

--- a/core/src/test/scala/com/lightbend/paradox/markdown/MarkdownBaseSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/MarkdownBaseSpec.scala
@@ -19,7 +19,7 @@ package com.lightbend.paradox.markdown
 import com.lightbend.paradox.tree.Tree.{ Forest, Location }
 import java.io.{ File, PrintWriter }
 import org.scalatest.{ FlatSpec, Matchers }
-import com.lightbend.paradox.template.{ CachedTemplates, PageTemplate }
+import com.lightbend.paradox.template.PageTemplate
 import java.nio.file._
 
 abstract class MarkdownBaseSpec extends FlatSpec with Matchers {
@@ -51,8 +51,8 @@ abstract class MarkdownBaseSpec extends FlatSpec with Matchers {
         val html = normalize(markdownWriter.write(page.markdown, context(loc)))
         val outputFile = new File(page.path)
         val emptyPageContext = PartialPageContent(page.properties.get, html)
-        val template = CachedTemplates(new File(templateDirectory.toString), page.properties(Page.Properties.DefaultLayoutMdIndicator, PageTemplate.DefaultName))
-        template.write(emptyPageContext, outputFile, new PageTemplate.ErrorLogger(s => println("[error] " + s)))
+        val template = new PageTemplate(new File(templateDirectory.toString))
+        template.write(page.properties(Page.Properties.DefaultLayoutMdIndicator, template.defaultName), emptyPageContext, outputFile, new PageTemplate.ErrorLogger(s => println("[error] " + s)))
         val fileContent = fileToContent(outputFile)
         outputFile.delete
         render(loc.next, rendered :+ (page.path, normalize(fileContent)))

--- a/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxKeys.scala
+++ b/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxKeys.scala
@@ -33,6 +33,7 @@ trait ParadoxKeys {
   val paradoxTheme = settingKey[Option[ModuleID]]("Web module name of the paradox theme, otherwise local template.")
   val paradoxThemeDirectory = taskKey[File]("Sync combined theme and local template to a directory.")
   val paradoxOverlayDirectories = settingKey[Seq[File]]("Directory containing common source files for configuration.")
+  val paradoxDefaultTemplateName = settingKey[String]("Name of default template for generating pages.")
   val paradoxTemplate = taskKey[PageTemplate]("PageTemplate to use when generating HTML pages.")
   val paradoxVersion = settingKey[String]("Paradox plugin version.")
 }

--- a/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
+++ b/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
@@ -20,7 +20,7 @@ import sbt._
 import sbt.Keys._
 
 import com.lightbend.paradox.ParadoxProcessor
-import com.lightbend.paradox.template.{ PageTemplate, CachedTemplates }
+import com.lightbend.paradox.template.PageTemplate
 import com.typesafe.sbt.web.Import.{ Assets, WebKeys }
 import com.typesafe.sbt.web.SbtWeb
 
@@ -45,6 +45,7 @@ object ParadoxPlugin extends AutoPlugin {
     paradoxNavigationDepth := 2,
     paradoxProperties := Map.empty,
     paradoxTheme := Some(builtinParadoxTheme("generic")),
+    paradoxDefaultTemplateName := "page",
     paradoxLeadingBreadcrumbs := Nil,
     libraryDependencies ++= paradoxTheme.value.toSeq
   )
@@ -105,7 +106,7 @@ object ParadoxPlugin extends AutoPlugin {
       if (!dir.exists) {
         IO.createDirectory(dir)
       }
-      CachedTemplates(dir)
+      new PageTemplate(dir, paradoxDefaultTemplateName.value)
     },
 
     sourceDirectory in paradoxTemplate := (target in paradoxTheme).value, // result of combining published theme and local theme template
@@ -127,7 +128,7 @@ object ParadoxPlugin extends AutoPlugin {
         paradoxTargetSuffix.value,
         paradoxProperties.value,
         paradoxNavigationDepth.value,
-        paradoxThemeDirectory.value,
+        paradoxTemplate.value,
         new PageTemplate.ErrorLogger(s => streams.value.log.error(s))
       )
     },

--- a/plugin/src/sbt-test/paradox/template/build.sbt
+++ b/plugin/src/sbt-test/paradox/template/build.sbt
@@ -1,0 +1,7 @@
+lazy val templateTest = project
+  .in(file("."))
+  .enablePlugins(ParadoxPlugin)
+  .settings(
+    // set the generic theme to test overriding page.st
+    paradoxTheme := Some(builtinParadoxTheme("generic"))
+  )

--- a/plugin/src/sbt-test/paradox/template/changes/alt2.st
+++ b/plugin/src/sbt-test/paradox/template/changes/alt2.st
@@ -1,0 +1,1 @@
+Modified alternative template

--- a/plugin/src/sbt-test/paradox/template/changes/page2.st
+++ b/plugin/src/sbt-test/paradox/template/changes/page2.st
@@ -1,0 +1,1 @@
+Modified template

--- a/plugin/src/sbt-test/paradox/template/expected/page1.html
+++ b/plugin/src/sbt-test/paradox/template/expected/page1.html
@@ -1,0 +1,1 @@
+Override generic template

--- a/plugin/src/sbt-test/paradox/template/expected/page2.html
+++ b/plugin/src/sbt-test/paradox/template/expected/page2.html
@@ -1,0 +1,1 @@
+Modified template

--- a/plugin/src/sbt-test/paradox/template/expected/page3.html
+++ b/plugin/src/sbt-test/paradox/template/expected/page3.html
@@ -1,0 +1,1 @@
+Alternative template

--- a/plugin/src/sbt-test/paradox/template/expected/page4.html
+++ b/plugin/src/sbt-test/paradox/template/expected/page4.html
@@ -1,0 +1,1 @@
+Modified alternative template

--- a/plugin/src/sbt-test/paradox/template/project/plugins.sbt
+++ b/plugin/src/sbt-test/paradox/template/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % sys.props("project.version"))

--- a/plugin/src/sbt-test/paradox/template/src/main/paradox/_template/alt.st
+++ b/plugin/src/sbt-test/paradox/template/src/main/paradox/_template/alt.st
@@ -1,0 +1,1 @@
+Alternative template

--- a/plugin/src/sbt-test/paradox/template/src/main/paradox/_template/page.st
+++ b/plugin/src/sbt-test/paradox/template/src/main/paradox/_template/page.st
@@ -1,0 +1,1 @@
+Override generic template

--- a/plugin/src/sbt-test/paradox/template/src/main/paradox/page.md
+++ b/plugin/src/sbt-test/paradox/template/src/main/paradox/page.md
@@ -1,0 +1,1 @@
+# Test page

--- a/plugin/src/sbt-test/paradox/template/test
+++ b/plugin/src/sbt-test/paradox/template/test
@@ -1,0 +1,20 @@
+# check that the page.st from generic theme has been overridden
+> paradox
+$ must-mirror target/paradox/site/main/page.html expected/page1.html
+
+# make a change to page.st and check that the template has been updated
+$ copy-file changes/page2.st src/main/paradox/_template/page.st
+$ sleep 1000
+> paradox
+$ must-mirror target/paradox/site/main/page.html expected/page2.html
+
+# switch to a different default template
+> 'set paradoxDefaultTemplateName := "alt"'
+> paradox
+$ must-mirror target/paradox/site/main/page.html expected/page3.html
+
+# make a change to alt.st and check that the template has been updated
+$ copy-file changes/alt2.st src/main/paradox/_template/alt.st
+$ sleep 1000
+> paradox
+$ must-mirror target/paradox/site/main/page.html expected/page4.html


### PR DESCRIPTION
Having templates cached globally means that the template cannot be changed and the docs rebuilt in the same sbt process. So to change the template and rebuild, we need to keep restarting sbt / running in batch mode. Rather than invalidate the cache, I've just removed it completely. StringTemplate already provides caching for the template group, as far as I know. Also move the default template name to an sbt setting.

Also add an sbt-test that makes some changes to the template (and starts by overriding the generic template). This test will fail with the cached templates, without these changes.

Related issues: #91 and #101.