### PR TITLE
Add description about groups with div and note.

### DIFF
--- a/docs/src/main/paradox/features/groups.md
+++ b/docs/src/main/paradox/features/groups.md
@@ -81,6 +81,36 @@ Text describing the @java[Java variant]@scala[Scala variant containing ***markdo
 
 Text describing the @java[Java variant]@scala[Scala variant containing ***markdown*** and @ref:[Linking](linking.md)].
 
+### Directives
+
+You can also use groups with directives such as `@@@ div` [(link)](http://developer.lightbend.com/docs/paradox/latest/features/css-friendliness.html#div)
+and `@@@ note` [(link)](http://developer.lightbend.com/docs/paradox/latest/features/css-friendliness.html#div) as follows:
+
+```
+@@@ div { .group-scala }
+
+This only shows up when the `group` is "scala"
+
+@@@
+
+@@@ note { .group-java }
+
+This only shows up when the `group` is "java"
+
+@@@
+```
+
+@@@ div { .group-scala }
+
+This only shows up when the `group` is "scala"
+
+@@@
+
+@@@ note { .group-java }
+
+This only shows up when the `group` is "java"
+
+@@@
 
 ## Behavior
 


### PR DESCRIPTION
Refs #62 
I think it is nicer to include the description for groups with "directives" (let me know if "directives" is not the right terminology) like `@@@ div` and `@@@ note`.

## When group = "scala"

![image](https://cloud.githubusercontent.com/assets/7414320/26530963/cd85c162-441a-11e7-9c17-cad461966a9c.png)

## When group = "java"

![image](https://cloud.githubusercontent.com/assets/7414320/26530959/c168f336-441a-11e7-9686-ae10b7eda60e.png)
