### PR TITLE
Fiddle cleanups

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -298,15 +298,8 @@ case class SnipDirective(page: Page, variables: Map[String, String])
     try {
       val labels = node.attributes.values("identifier").asScala
       val source = resolvedSource(node, page)
-      val file =
-        if (source startsWith "$") {
-          val baseKey = source.drop(1).takeWhile(_ != '$')
-          val base = new File(PropertyUrl(s"snip.$baseKey.base_dir", variables.get).base.trim)
-          val effectiveBase = if (base.isAbsolute) base else new File(page.file.getParentFile, base.toString)
-          new File(effectiveBase, source.drop(baseKey.length + 2))
-        } else new File(page.file.getParentFile, source)
-      val text = Snippet(file, labels)
-      val lang = Option(node.attributes.value("type")).getOrElse(Snippet.language(file))
+      val (text, snippetLang) = Snippet("snip", source, labels, page, variables)
+      val lang = Option(node.attributes.value("type")).getOrElse(snippetLang)
       val group = Option(node.attributes.value("group")).getOrElse("")
       new VerbatimGroupNode(text, lang, group).accept(visitor)
     } catch {
@@ -344,13 +337,7 @@ case class FiddleDirective(page: Page, variables: Map[String, String])
       val extraParams = node.attributes.value("extraParams", "theme=light")
       val cssStyle = node.attributes.value("cssStyle", "overflow: hidden;")
       val source = resolvedSource(node, page)
-      val file = if (source startsWith "$") {
-        val baseKey = source.drop(1).takeWhile(_ != '$')
-        val base = new File(PropertyUrl(s"fiddle.$baseKey.base_dir", variables.get).base.trim)
-        val effectiveBase = if (base.isAbsolute) base else new File(page.file.getParentFile, base.toString)
-        new File(effectiveBase, source.drop(baseKey.length + 2))
-      } else new File(page.file.getParentFile, source)
-      val text = Snippet(file, labels)
+      val (text, _) = Snippet("fiddle", source, labels, page, variables)
 
       val fiddleSource = java.net.URLEncoder.encode(
         """import fiddle.Fiddle, Fiddle.println

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -351,18 +351,16 @@ case class FiddleDirective(page: Page, variables: Map[String, String])
         new File(effectiveBase, source.drop(baseKey.length + 2))
       } else new File(page.file.getParentFile, source)
       val text = Snippet(file, labels)
-      val lang = Option(node.attributes.value("type")).getOrElse(Snippet.language(file))
 
       val fiddleSource = java.net.URLEncoder.encode(
-        """
-            |import fiddle.Fiddle, Fiddle.println
-            | @scalajs.js.annotation.JSExport
-            | object ScalaFiddle {
-            |   // $FiddleStart
-            |""".stripMargin + text + """
-            |   // $FiddleEnd
-            | }
-          """.stripMargin, "UTF-8")
+        """import fiddle.Fiddle, Fiddle.println
+          |@scalajs.js.annotation.JSExport
+          |object ScalaFiddle {
+          |  // $FiddleStart
+          |""".stripMargin + text + """
+          |  // $FiddleEnd
+          |}
+          |""".stripMargin, "UTF-8")
 
       printer.println.print(s"""
         <iframe class="$cssClass" $width $height src="$baseUrl?$extraParams&source=$fiddleSource" frameborder="0" style="$cssStyle"></iframe>

--- a/core/src/test/scala/com/lightbend/paradox/markdown/FiddleDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/FiddleDirectiveSpec.scala
@@ -28,7 +28,7 @@ class FiddleDirectiveSpec extends MarkdownBaseSpec {
     |@@fiddle [FiddleDirectiveSpec.scala](./FiddleDirectiveSpec.scala) { #fiddle_code extraParams=theme=light&layout=v75 cssStyle=width:100%; }
     """).values.head shouldEqual html("""
       |<iframe class="fiddle" src=
-"https://embed.scalafiddle.io/embed?theme=light&amp;layout=v75&amp;source=%0Aimport+fiddle.Fiddle%2C+Fiddle.println%0A+%40scalajs.js.annotation.JSExport%0A+object+ScalaFiddle+%7B%0A+++%2F%2F+%24FiddleStart%0Aval+sourcePath+%3D+new+java.io.File%28%22.%22%29.getAbsolutePath+%2B+%22%2Fcore%2Fsrc%2Ftest%2Fscala%2F%22%0A+++%2F%2F+%24FiddleEnd%0A+%7D%0A++++++++++"
+"https://embed.scalafiddle.io/embed?theme=light&amp;layout=v75&amp;source=import+fiddle.Fiddle%2C+Fiddle.println%0A%40scalajs.js.annotation.JSExport%0Aobject+ScalaFiddle+%7B%0A++%2F%2F+%24FiddleStart%0Aval+sourcePath+%3D+new+java.io.File%28%22.%22%29.getAbsolutePath+%2B+%22%2Fcore%2Fsrc%2Ftest%2Fscala%2F%22%0A++%2F%2F+%24FiddleEnd%0A%7D%0A"
  frameborder="0" style="width:100%;"></iframe>
     """.stripMargin)
   }
@@ -39,7 +39,7 @@ class FiddleDirectiveSpec extends MarkdownBaseSpec {
       |@@fiddle [FiddleDirectiveSpec.scala](./FiddleDirectiveSpec.scala) { #fiddle_code width=100px height=100px extraParams=theme=light&layout=v75 cssStyle=width:100%; }
       """).values.head shouldEqual html("""
         |<iframe class="fiddle" width="100px" height="100px" src=
-"https://embed.scalafiddle.io/embed?theme=light&amp;layout=v75&amp;source=%0Aimport+fiddle.Fiddle%2C+Fiddle.println%0A+%40scalajs.js.annotation.JSExport%0A+object+ScalaFiddle+%7B%0A+++%2F%2F+%24FiddleStart%0Aval+sourcePath+%3D+new+java.io.File%28%22.%22%29.getAbsolutePath+%2B+%22%2Fcore%2Fsrc%2Ftest%2Fscala%2F%22%0A+++%2F%2F+%24FiddleEnd%0A+%7D%0A++++++++++"
+"https://embed.scalafiddle.io/embed?theme=light&amp;layout=v75&amp;source=import+fiddle.Fiddle%2C+Fiddle.println%0A%40scalajs.js.annotation.JSExport%0Aobject+ScalaFiddle+%7B%0A++%2F%2F+%24FiddleStart%0Aval+sourcePath+%3D+new+java.io.File%28%22.%22%29.getAbsolutePath+%2B+%22%2Fcore%2Fsrc%2Ftest%2Fscala%2F%22%0A++%2F%2F+%24FiddleEnd%0A%7D%0A"
  frameborder="0" style="width:100%;"></iframe>
       """.stripMargin)
   }
@@ -50,7 +50,7 @@ class FiddleDirectiveSpec extends MarkdownBaseSpec {
       |@@fiddle [FiddleDirectiveSpec.scala](./FiddleDirectiveSpec.scala) { #fiddle_code baseUrl=http://shadowscalafiddle.io width=100px height=100px extraParams=theme=light&layout=v75 cssStyle=width:100%; }
       """).values.head shouldEqual html("""
         |<iframe class="fiddle" width="100px" height="100px" src=
-"http://shadowscalafiddle.io?theme=light&amp;layout=v75&amp;source=%0Aimport+fiddle.Fiddle%2C+Fiddle.println%0A+%40scalajs.js.annotation.JSExport%0A+object+ScalaFiddle+%7B%0A+++%2F%2F+%24FiddleStart%0Aval+sourcePath+%3D+new+java.io.File%28%22.%22%29.getAbsolutePath+%2B+%22%2Fcore%2Fsrc%2Ftest%2Fscala%2F%22%0A+++%2F%2F+%24FiddleEnd%0A+%7D%0A++++++++++"
+"http://shadowscalafiddle.io?theme=light&amp;layout=v75&amp;source=import+fiddle.Fiddle%2C+Fiddle.println%0A%40scalajs.js.annotation.JSExport%0Aobject+ScalaFiddle+%7B%0A++%2F%2F+%24FiddleStart%0Aval+sourcePath+%3D+new+java.io.File%28%22.%22%29.getAbsolutePath+%2B+%22%2Fcore%2Fsrc%2Ftest%2Fscala%2F%22%0A++%2F%2F+%24FiddleEnd%0A%7D%0A"
  frameborder="0" style="width:100%;"></iframe>
       """.stripMargin)
   }


### PR DESCRIPTION
Trims unrelated space from fiddles and make the snip and fiddle directives share more code for extracting text.