### PR TITLE
Bump paradox plugin to version 0.3.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,7 +19,7 @@ addSbtPlugin("org.scalariform"       % "sbt-scalariform" % "1.7.1")
 addSbtPlugin("de.heikoseeberger"     % "sbt-header"      % "2.0.0")
 addSbtPlugin("org.foundweekends"     % "sbt-bintray"     % "0.5.1")
 addSbtPlugin("com.jsuereth"          % "sbt-pgp"         % "1.1.0-M1")
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox"     % "0.2.12")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox"     % "0.3.0")
 
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -30,10 +30,7 @@ lazy val metaThemePlugin = (project in file("theme-plugin"))
   .settings(
     sbtPlugin := true,
     scalaVersion := "2.10.6",
-    // Change this version to 1.4.2 after a new version of sbt-paradox has been published.
-    // It can't be changed now since there will be a failure in docs/paradox where the
-    // cache directory structure of the new sbt-web and the old sbt-paradox clashes.
-    addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.1.1"),
+    addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.4.2"),
     unmanagedSourceDirectories in Compile :=
       mirrorScalaSource((baseDirectory in ThisBuild).value.getParentFile / "theme-plugin")
   )


### PR DESCRIPTION
Fixes the example display on the library dependency page.