### PR TITLE
Disable autoScalaLibrary in theme projects

### DIFF
--- a/theme-plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxThemePlugin.scala
+++ b/theme-plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxThemePlugin.scala
@@ -39,6 +39,7 @@ object ParadoxThemePlugin extends AutoPlugin {
   override def requires = SbtWeb
 
   override def projectSettings = minimalWebjarSettings ++ Seq(
+    autoScalaLibrary := false,
     crossPaths := false
   )
 


### PR DESCRIPTION
Themes should not depend on Scala, since the artifacts are not cross
versioned.

---

Per discussion here: https://gitter.im/sbt/sbt-site?at=59cab44f614889d475415026

`com.lightbend.paradox:paradox-theme-generic:0.3.0` currently brings in Scala 2.12.

<img width="632" alt="screen shot 2017-09-26 at 20 54 14" src="https://user-images.githubusercontent.com/8417/30890773-f26a0380-a2fc-11e7-9947-19c9cc753176.png">
