### PR TITLE
Allow site root relative base URLs in *doc & extref directives

### DIFF
--- a/core/src/test/scala/com/lightbend/paradox/markdown/ExtRefDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/ExtRefDirectiveSpec.scala
@@ -22,6 +22,7 @@ class ExtRefDirectiveSpec extends MarkdownBaseSpec {
     "extref.rfc.base_url" -> "http://tools.ietf.org/html/rfc%s",
     "extref.issue.base_url" -> "https://github.com/lightbend/paradox/issues/%s",
     "extref.docs.base_url" -> "https://docs.example.org/%s",
+    "extref.root_relative.base_url" -> ".../root/relative/%s",
     "extref.broken.base_url" -> "https://c|%s")
 
   "ExtRef directive" should "create links using configured URL templates" in {
@@ -41,6 +42,11 @@ class ExtRefDirectiveSpec extends MarkdownBaseSpec {
   it should "support 'extref:' as an alternative name" in {
     markdown("@extref:[RFC 1234](rfc:1234)") shouldEqual
       html("""<p><a href="http://tools.ietf.org/html/rfc1234">RFC 1234</a></p>""")
+  }
+
+  it should "support root relative '...' base urls" in {
+    markdown("@extref:[Root Relative 1729](root_relative:1729)") shouldEqual
+      html("""<p><a href="root/relative/1729">Root Relative 1729</a></p>""")
   }
 
   it should "handle anchored links correctly" in {

--- a/core/src/test/scala/com/lightbend/paradox/markdown/JavadocDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/JavadocDirectiveSpec.scala
@@ -25,6 +25,7 @@ class JavadocDirectiveSpec extends MarkdownBaseSpec {
     "javadoc.java.base_url" -> "https://docs.oracle.com/javase/8/docs/api/",
     "javadoc.akka.base_url" -> "http://doc.akka.io/japi/akka/2.4.10",
     "javadoc.akka.http.base_url" -> "http://doc.akka.io/japi/akka-http/10.0.0/index.html",
+    "javadoc.root.relative.base_url" -> ".../javadoc/api/",
     "javadoc.broken.base_url" -> "https://c|"
   )
 
@@ -36,6 +37,11 @@ class JavadocDirectiveSpec extends MarkdownBaseSpec {
   it should "support 'javadoc:' as an alternative name" in {
     markdown("@javadoc:[Publisher](org.reactivestreams.Publisher)") shouldEqual
       html("""<p><a href="http://www.reactive-streams.org/reactive-streams-1.0.0-javadoc/?org/reactivestreams/Publisher.html">Publisher</a></p>""")
+  }
+
+  it should "support root relative '...' base urls" in {
+    markdown("@javadoc[Url](root.relative.Url)") shouldEqual
+      html("""<p><a href="javadoc/api/?root/relative/Url.html">Url</a></p>""")
   }
 
   it should "handle method links correctly" in {

--- a/core/src/test/scala/com/lightbend/paradox/markdown/ScaladocDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/ScaladocDirectiveSpec.scala
@@ -23,6 +23,7 @@ class ScaladocDirectiveSpec extends MarkdownBaseSpec {
     "scaladoc.scala.base_url" -> "http://www.scala-lang.org/api/2.11.8/",
     "scaladoc.akka.base_url" -> "http://doc.akka.io/api/akka/2.4.10",
     "scaladoc.akka.http.base_url" -> "http://doc.akka.io/api/akka-http/10.0.0",
+    "scaladoc.root.relative.base_url" -> ".../scaladoc/api/",
     "scaladoc.broken.base_url" -> "https://c|"
   )
 
@@ -34,6 +35,11 @@ class ScaladocDirectiveSpec extends MarkdownBaseSpec {
   it should "support 'scaladoc:' as an alternative name" in {
     markdown("@scaladoc:[Model](org.example.Model)") shouldEqual
       html("""<p><a href="http://example.org/api/0.1.2/org/example/Model.html">Model</a></p>""")
+  }
+
+  it should "support root relative '...' base urls" in {
+    markdown("@scaladoc:[Url](root.relative.Url)") shouldEqual
+      html("""<p><a href="scaladoc/api/root/relative/Url.html">Url</a></p>""")
   }
 
   it should "handle method links correctly" in {

--- a/docs/src/main/paradox/features/linking.md
+++ b/docs/src/main/paradox/features/linking.md
@@ -73,6 +73,8 @@ associated with the configured `scalaVersion`. If the sbt project's
 `apiURL` setting is configured, it is used as the default Scaladoc base
 URL.
 
+The `@scaladoc` directive also supports site root relative base URLs using the `.../` syntax.
+
 #### @javadoc directive
 
 Use the `@javadoc` directives to link to Javadoc sites based on the package
@@ -91,6 +93,8 @@ Then `@javadoc[Http](akka.http.javadsl.Http#shutdownAllConnectionPools--)` will 
 
 By default, `javadoc.java.base_url` is configured to the Javadoc
 associated with the `java.specification.version` system property.
+
+The `@javadoc` directive also supports site root relative base URLs using the `.../` syntax.
 
 #### @github directive
 
@@ -131,6 +135,8 @@ extref.rfc.base_url=http://tools.ietf.org/html/rfc%s
 
 then `@extref[RFC 2119](rfc:2119)` will resolve to the URL
 <http://tools.ietf.org/html/rfc2119>.
+
+The `@extref` directive also supports site root relative base URLs using the `.../` syntax.
 
 #### image.base_url
 


### PR DESCRIPTION
Not sure if this is the way to go, but I wanted to be able to link to APIs, and files that end up in the same site tree as the generated paradox site, so I added the possibility to have base URLs starting with `.../` that are converted to site root relative URLs, in the same way that the image links are converted.