### PR TITLE
Fix java URLEncoding akka #24099

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -381,6 +381,7 @@ case class FiddleDirective(page: Page, variables: Map[String, String])
           |  // $FiddleEnd
           |}
           |""".stripMargin, "UTF-8")
+        .replace("+", "%20") // due to: https://stackoverflow.com/questions/4737841/urlencoder-not-able-to-translate-space-character
 
       printer.println.print(s"""
         <iframe class="$cssClass" $width $height src="$baseUrl?$extraParams&source=$fiddleSource" frameborder="0" style="$cssStyle"></iframe>

--- a/core/src/test/scala/com/lightbend/paradox/markdown/FiddleDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/FiddleDirectiveSpec.scala
@@ -28,7 +28,7 @@ class FiddleDirectiveSpec extends MarkdownBaseSpec {
     |@@fiddle [FiddleDirectiveSpec.scala](./FiddleDirectiveSpec.scala) { #fiddle_code extraParams=theme=light&layout=v75 cssStyle=width:100%; }
     """).values.head shouldEqual html("""
       |<iframe class="fiddle" src=
-"https://embed.scalafiddle.io/embed?theme=light&amp;layout=v75&amp;source=import+fiddle.Fiddle%2C+Fiddle.println%0A%40scalajs.js.annotation.JSExport%0Aobject+ScalaFiddle+%7B%0A++%2F%2F+%24FiddleStart%0Aval+sourcePath+%3D+new+java.io.File%28%22.%22%29.getAbsolutePath+%2B+%22%2Fcore%2Fsrc%2Ftest%2Fscala%2F%22%0A++%2F%2F+%24FiddleEnd%0A%7D%0A"
+"https://embed.scalafiddle.io/embed?theme=light&amp;layout=v75&amp;source=import%20fiddle.Fiddle%2C%20Fiddle.println%0A%40scalajs.js.annotation.JSExport%0Aobject%20ScalaFiddle%20%7B%0A%20%20%2F%2F%20%24FiddleStart%0Aval%20sourcePath%20%3D%20new%20java.io.File%28%22.%22%29.getAbsolutePath%20%2B%20%22%2Fcore%2Fsrc%2Ftest%2Fscala%2F%22%0A%20%20%2F%2F%20%24FiddleEnd%0A%7D%0A"
  frameborder="0" style="width:100%;"></iframe>
     """.stripMargin)
   }
@@ -39,7 +39,7 @@ class FiddleDirectiveSpec extends MarkdownBaseSpec {
       |@@fiddle [FiddleDirectiveSpec.scala](./FiddleDirectiveSpec.scala) { #fiddle_code width=100px height=100px extraParams=theme=light&layout=v75 cssStyle=width:100%; }
       """).values.head shouldEqual html("""
         |<iframe class="fiddle" width="100px" height="100px" src=
-"https://embed.scalafiddle.io/embed?theme=light&amp;layout=v75&amp;source=import+fiddle.Fiddle%2C+Fiddle.println%0A%40scalajs.js.annotation.JSExport%0Aobject+ScalaFiddle+%7B%0A++%2F%2F+%24FiddleStart%0Aval+sourcePath+%3D+new+java.io.File%28%22.%22%29.getAbsolutePath+%2B+%22%2Fcore%2Fsrc%2Ftest%2Fscala%2F%22%0A++%2F%2F+%24FiddleEnd%0A%7D%0A"
+"https://embed.scalafiddle.io/embed?theme=light&amp;layout=v75&amp;source=import%20fiddle.Fiddle%2C%20Fiddle.println%0A%40scalajs.js.annotation.JSExport%0Aobject%20ScalaFiddle%20%7B%0A%20%20%2F%2F%20%24FiddleStart%0Aval%20sourcePath%20%3D%20new%20java.io.File%28%22.%22%29.getAbsolutePath%20%2B%20%22%2Fcore%2Fsrc%2Ftest%2Fscala%2F%22%0A%20%20%2F%2F%20%24FiddleEnd%0A%7D%0A"
  frameborder="0" style="width:100%;"></iframe>
       """.stripMargin)
   }
@@ -50,7 +50,7 @@ class FiddleDirectiveSpec extends MarkdownBaseSpec {
       |@@fiddle [FiddleDirectiveSpec.scala](./FiddleDirectiveSpec.scala) { #fiddle_code baseUrl=http://shadowscalafiddle.io width=100px height=100px extraParams=theme=light&layout=v75 cssStyle=width:100%; }
       """).values.head shouldEqual html("""
         |<iframe class="fiddle" width="100px" height="100px" src=
-"http://shadowscalafiddle.io?theme=light&amp;layout=v75&amp;source=import+fiddle.Fiddle%2C+Fiddle.println%0A%40scalajs.js.annotation.JSExport%0Aobject+ScalaFiddle+%7B%0A++%2F%2F+%24FiddleStart%0Aval+sourcePath+%3D+new+java.io.File%28%22.%22%29.getAbsolutePath+%2B+%22%2Fcore%2Fsrc%2Ftest%2Fscala%2F%22%0A++%2F%2F+%24FiddleEnd%0A%7D%0A"
+"http://shadowscalafiddle.io?theme=light&amp;layout=v75&amp;source=import%20fiddle.Fiddle%2C%20Fiddle.println%0A%40scalajs.js.annotation.JSExport%0Aobject%20ScalaFiddle%20%7B%0A%20%20%2F%2F%20%24FiddleStart%0Aval%20sourcePath%20%3D%20new%20java.io.File%28%22.%22%29.getAbsolutePath%20%2B%20%22%2Fcore%2Fsrc%2Ftest%2Fscala%2F%22%0A%20%20%2F%2F%20%24FiddleEnd%0A%7D%0A"
  frameborder="0" style="width:100%;"></iframe>
       """.stripMargin)
   }


### PR DESCRIPTION
Fix for Akka https://github.com/akka/akka/issues/24099
Actually this was expected behavior, since scalafiddle is built on top of Akka-Http, probably something changed in the meanwhile in URL decoding in Akka HTTP itself (now is correct indeed).

cc. @ochrons @2m 