### PR TITLE
Speed up @ref directive by pre-calculating part of mappings

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
+++ b/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
@@ -59,7 +59,7 @@ class ParadoxProcessor(reader: Reader = new Reader, writer: Writer = new Writer)
       case Some(loc) =>
         val page = loc.tree.label
         val pageProperties = properties ++ page.properties.get
-        val currentMapping = Path.generateTargetFile(Path.relativeLocalPath(page.rootSrcPage, page.file.getPath), globalPageMappings)_
+        val currentMapping = Path.generateTargetFile(Path.relativeLocalPath(page.rootSrcPage, page.file.getPath), globalPageMappings)
         val writerContext = Writer.Context(loc, paths, currentMapping, sourceSuffix, targetSuffix, groups, pageProperties)
         val pageContext = PageContents(leadingBreadcrumbs, groups, loc, writer, writerContext, navToc, pageToc)
         val outputFile = new File(outputDirectory, page.path)

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
@@ -226,12 +226,15 @@ object Path {
   /**
    * Provide the final target file given a particular source file/link
    */
-  def generateTargetFile(localPath: String, globalPageMappings: Map[String, String])(link: String): String = {
+  def generateTargetFile(localPath: String, globalPageMappings: Map[String, String]): String => String = {
     val mappings = relativeMapping(localPath, globalPageMappings)
-    val uri = new URI(localPath).resolve(new URI(link))
-    mappings.get(uri.getPath) match {
-      case Some(p) => p + Option(uri.getFragment).fold("")("#".+)
-      case None    => sys.error(s"No reference link corresponding to $link")
+
+    { link =>
+      val uri = new URI(localPath).resolve(new URI(link))
+      mappings.get(uri.getPath) match {
+        case Some(p) => p + Option(uri.getFragment).fold("")("#".+)
+        case None    => sys.error(s"No reference link corresponding to $link")
+      }
     }
   }
 

--- a/core/src/test/scala/com/lightbend/paradox/markdown/PathSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/PathSpec.scala
@@ -101,7 +101,7 @@ class PathSpec extends FlatSpec with Matchers {
 
   "Path.generateTargetFile" should "return the corresponding target file given the relative mapping for the current file" in {
     val (mappings, sourcePath) = provideRelativeMapping
-    val newMapping = Path.generateTargetFile(sourcePath, mappings)_
+    val newMapping = Path.generateTargetFile(sourcePath, mappings)
 
     newMapping("../../index.md") shouldEqual "../../index.html"
     the[RuntimeException] thrownBy {
@@ -112,7 +112,7 @@ class PathSpec extends FlatSpec with Matchers {
 
   it should "return the source file for fragment links" in {
     val (mappings, sourcePath) = provideRelativeMapping
-    val newMapping = Path.generateTargetFile(sourcePath, mappings)_
+    val newMapping = Path.generateTargetFile(sourcePath, mappings)
 
     newMapping("#frag") shouldEqual "source.html#frag"
   }


### PR DESCRIPTION
This means that `relativeMapping` are calculated only once per run instead of for every invocation of a `@ref` directive.

For akka-http docs this gets ~30% total performance boost from 9-10 seconds to 6 seconds.