### PR TITLE
Allow reusing InlineWrapDirective for other element types

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -501,7 +501,7 @@ case class WrapDirective(typ: String) extends ContainerBlockDirective(Array(typ,
  *
  * Wraps inner contents in a `span`, optionally with custom `id` and/or `class` attributes.
  */
-case class InlineWrapDirective(typ: String) extends InlineDirective("span") {
+case class InlineWrapDirective(typ: String) extends InlineDirective(typ) {
   def render(node: DirectiveNode, visitor: Visitor, printer: Printer): Unit = {
     val id =
       node.attributes.identifier match {

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -501,7 +501,8 @@ case class WrapDirective(typ: String) extends ContainerBlockDirective(Array(typ,
  *
  * Wraps inner contents in a `span`, optionally with custom `id` and/or `class` attributes.
  */
-case class InlineWrapDirective(typ: String) extends InlineDirective(typ) {
+case class InlineWrapDirective(typ: String) extends InlineDirective(Array(typ, typ.toUpperCase): _*) {
+
   def render(node: DirectiveNode, visitor: Visitor, printer: Printer): Unit = {
     val id =
       node.attributes.identifier match {

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
@@ -95,7 +95,7 @@ object Page {
     val rootSrcPage = Path.relativeRootPath(page.file, page.path)
     val (h1, subheaders) = page.headers match {
       case h :: hs => (Header(h.label.path, h.label.markdown, h.label.group), h.children ++ hs)
-      case Nil      => (Header(targetPath, new SpecialTextNode(targetPath), None), Nil)
+      case Nil     => (Header(targetPath, new SpecialTextNode(targetPath), None), Nil)
     }
     val headers = subheaders map (_ map (h => Header(h.path, h.markdown, h.group)))
     Page(page.file, targetPath, rootSrcPage, h1.label, h1, headers, page.markdown, h1.group, properties)


### PR DESCRIPTION
For example you could add an `InlineWrapDirective("aside")` to allow
`@aside[text] { .blue }` leading to `<aside class="blue">text</aside>`.