### PR TITLE
bump Scala and sbt versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 jdk: oraclejdk8
-scala: 2.10.6
+scala: 2.10.7
 script: sbt verify
 
 cache:

--- a/build.sbt
+++ b/build.sbt
@@ -21,8 +21,8 @@ lazy val paradox = project
   .settings(inThisBuild(List(
     organization := "com.lightbend.paradox",
     licenses += "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"),
-    scalaVersion := "2.10.6",
-    crossScalaVersions := Seq("2.10.6", "2.12.3"),
+    scalaVersion := "2.10.7",
+    crossScalaVersions := Seq("2.10.7", "2.12.6"),
     organizationName := "lightbend",
     organizationHomepage := Some(url("http://lightbend.com/")),
     homepage := Some(url("https://github.com/lightbend/paradox")),

--- a/core/src/test/scala/com/lightbend/paradox/markdown/ScaladocDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/ScaladocDirectiveSpec.scala
@@ -20,7 +20,7 @@ class ScaladocDirectiveSpec extends MarkdownBaseSpec {
 
   implicit val context = writerContextWithProperties(
     "scaladoc.base_url" -> "http://example.org/api/0.1.2/",
-    "scaladoc.scala.base_url" -> "http://www.scala-lang.org/api/2.11.8/",
+    "scaladoc.scala.base_url" -> "http://www.scala-lang.org/api/2.11.12/",
     "scaladoc.akka.base_url" -> "http://doc.akka.io/api/akka/2.4.10",
     "scaladoc.akka.http.base_url" -> "http://doc.akka.io/api/akka-http/10.0.0",
     "scaladoc.root.relative.base_url" -> ".../scaladoc/api/",
@@ -44,7 +44,7 @@ class ScaladocDirectiveSpec extends MarkdownBaseSpec {
 
   it should "handle method links correctly" in {
     markdown("@scaladoc[???](scala.Predef$#???:Nothing)") shouldEqual
-      html("""<p><a href="http://www.scala-lang.org/api/2.11.8/scala/Predef$.html#???:Nothing">???</a></p>""")
+      html("""<p><a href="http://www.scala-lang.org/api/2.11.12/scala/Predef$.html#???:Nothing">???</a></p>""")
 
     markdown(
       """@scaladoc:[Actor#preStart]
@@ -97,15 +97,15 @@ class ScaladocDirectiveSpec extends MarkdownBaseSpec {
 
   it should "support Scala 2.11 links" in {
     implicit val context = writerContextWithProperties(
-      "scaladoc.scala.base_url" -> "http://www.scala-lang.org/api/2.11.11/",
-      "scaladoc.version" -> "2.11.11")
+      "scaladoc.scala.base_url" -> "http://www.scala-lang.org/api/2.11.12/",
+      "scaladoc.version" -> "2.11.12")
 
     markdown("@scaladoc[Int](scala.Int)") shouldEqual
-      html("""<p><a href="http://www.scala-lang.org/api/2.11.11/scala/Int.html">Int</a></p>""")
+      html("""<p><a href="http://www.scala-lang.org/api/2.11.12/scala/Int.html">Int</a></p>""")
     markdown("@scaladoc[Codec$](scala.io.Codec$)") shouldEqual
-      html("""<p><a href="http://www.scala-lang.org/api/2.11.11/scala/io/Codec$.html">Codec$</a></p>""")
+      html("""<p><a href="http://www.scala-lang.org/api/2.11.12/scala/io/Codec$.html">Codec$</a></p>""")
     markdown("@scaladoc[scala.io package](scala.io.package)") shouldEqual
-      html("""<p><a href="http://www.scala-lang.org/api/2.11.11/scala/io/package.html">scala.io package</a></p>""")
+      html("""<p><a href="http://www.scala-lang.org/api/2.11.12/scala/io/package.html">scala.io package</a></p>""")
   }
 
   it should "support referenced links" in {

--- a/plugin/src/sbt-test/paradox/parameterized-links/build.sbt
+++ b/plugin/src/sbt-test/paradox/parameterized-links/build.sbt
@@ -2,7 +2,7 @@ val akkaVersion = "2.4.10"
 val akkaHttpVersion = "10.0.0"
 
 version := "0.1.0"
-scalaVersion := "2.11.8"
+scalaVersion := "2.11.12"
 
 enablePlugins(ParadoxPlugin)
 paradoxTheme := None

--- a/plugin/src/sbt-test/paradox/parameterized-links/expected/scaladoc.html
+++ b/plugin/src/sbt-test/paradox/parameterized-links/expected/scaladoc.html
@@ -1,3 +1,3 @@
-<p>Use a <a href="http://www.scala-lang.org/api/2.11.8/scala/concurrent/Future.html">Future</a> to avoid that long running operations block the <a href="http://doc.akka.io/api/akka/2.4.10/akka/actor/Actor.html">Actor</a>.</p>
+<p>Use a <a href="http://www.scala-lang.org/api/2.11.12/scala/concurrent/Future.html">Future</a> to avoid that long running operations block the <a href="http://doc.akka.io/api/akka/2.4.10/akka/actor/Actor.html">Actor</a>.</p>
 <p><a href="http://doc.akka.io/api/akka-http/10.0.0/akka/http/scaladsl/Http$.html">Http</a></p>
 <p><a href="https://example.org/api/0.1.0/org/example/Server.html#start():Unit">Server#start</a></p>

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -32,10 +32,10 @@ object Common extends AutoPlugin {
   // AutomateHeaderPlugin is not an allRequirements-AutoPlugin, so explicitly add settings here:
   override def projectSettings = AutomateHeaderPlugin.projectSettings ++ Seq(
     scalaVersion := { (sbtBinaryVersion in pluginCrossBuild).value match {
-      case "0.13" => "2.10.6"
-      case _ => "2.12.3"
+      case "0.13" => "2.10.7"
+      case _ => "2.12.6"
     }},
-    crossSbtVersions := Seq("0.13.16", "1.0.0"),
+    crossSbtVersions := Seq("0.13.17", "1.0.0"),
     // fixed in https://github.com/sbt/sbt/pull/3397 (for sbt 0.13.17)
     sbtBinaryVersion in update := (sbtBinaryVersion in pluginCrossBuild).value,
     scalacOptions ++= Seq("-encoding", "UTF-8", "-unchecked", "-deprecation", "-feature"),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -29,7 +29,7 @@ lazy val metaroot = (project in file(".")).
 lazy val metaThemePlugin = (project in file("theme-plugin"))
   .settings(
     sbtPlugin := true,
-    scalaVersion := "2.10.6",
+    scalaVersion := "2.10.7",
     addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.4.2"),
     unmanagedSourceDirectories in Compile :=
       mirrorScalaSource((baseDirectory in ThisBuild).value.getParentFile / "theme-plugin")


### PR DESCRIPTION
this is needed for the Scala 2.12 community build running
on JDK 9: https://github.com/scala/community-builds/issues/609

it isn't important yet if paradox actually builds, but the
build definition needs to build, and we need the 2.10.6 -> 2.10.7
bump for that

the other version bumps here are just for good measure.