### PR TITLE
Fixup multisnippet indent

### DIFF
--- a/core/src/test/scala/com/lightbend/paradox/markdown/SnipDirectiveSpec.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/SnipDirectiveSpec.scala
@@ -27,7 +27,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
   }
 
   "The `snip` directive" should "render code snippets" in {
-    markdown("""@@snip[example.scala](core/src/test/scala/com/lightbend/paradox/markdown/example.scala) {#example }""") shouldEqual html("""
+    markdown("""@@snip[example.scala](core/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #example }""") shouldEqual html("""
       |<pre class="prettyprint">
       |<code class="language-scala">
       |object example extends App {
@@ -79,6 +79,15 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
       |        System.out.println("Hello, World");
       |    }
       |}</code>
+      |</pre>""")
+  }
+
+  it should "trim indentation from snippets" in {
+    markdown("""@@snip[example.scala](core/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #indented-example }""") shouldEqual html("""
+      |<pre class="prettyprint">
+      |<code class="language-scala">
+      |case object Dent
+      |case object DoubleDent</code>
       |</pre>""")
   }
 

--- a/core/src/test/scala/com/lightbend/paradox/markdown/example.scala
+++ b/core/src/test/scala/com/lightbend/paradox/markdown/example.scala
@@ -29,3 +29,15 @@ object example extends App {
   println("Hello, World!")
 }
 //#example
+
+object IndentedExample {
+  //#indented-example
+  case object Dent
+  //#indented-example
+
+  object EventMore {
+    //#indented-example
+    case object DoubleDent
+    //#indented-example
+  }
+}


### PR DESCRIPTION
This adds intent tracking at the start of the block. This indent is then removed for every line of the block. The result is evenly indented multi-snippets even when the original code has different indentations for different snippets.