### PR TITLE
use sbt-pgp in a community-build-friendly way

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -126,7 +126,7 @@ releaseProcess := {
     setReleaseVersion,
     commitReleaseVersion,
     tagRelease,
-    releaseStepCommandAndRemaining("^ publish"),
+    releaseStepCommandAndRemaining("^ publishSigned"),
     releaseStepCommand("bintrayRelease"),
     releaseStepCommand("sonatypeRelease"),
     setNextVersion,

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -18,6 +18,7 @@ import sbt._
 import sbt.Keys._
 import bintray.{ BintrayKeys, BintrayPlugin }
 import com.typesafe.sbt.SbtPgp, SbtPgp.autoImport._
+import sbtrelease.ReleasePlugin.autoImport._
 
 /**
  * Publish to private bintray repository.
@@ -50,7 +51,7 @@ object SonatypePublish extends AutoPlugin {
       if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")
       else Some("releases" at nexus + "service/local/staging/deploy/maven2")
     },
-    publish := PgpKeys.publishSigned.value
+    releasePublishArtifactsAction := PgpKeys.publishSigned.value
   )
 }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,7 +19,7 @@ addSbtPlugin("org.scalariform"       % "sbt-scalariform" % "1.8.1")
 addSbtPlugin("de.heikoseeberger"     % "sbt-header"      % "4.0.0")
 addSbtPlugin("org.foundweekends"     % "sbt-bintray"     % "0.5.1")
 addSbtPlugin("org.xerial.sbt"        % "sbt-sonatype"    % "2.0")
-addSbtPlugin("com.jsuereth"          % "sbt-pgp"         % "1.1.0-M1")
+addSbtPlugin("com.jsuereth"          % "sbt-pgp"         % "1.1.1")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox"     % "0.3.2")
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value


### PR DESCRIPTION
dbuild uses `publish`, so we want to avoid having it interactively
prompt for PGP stuff.  I looked at how other projects that use sbt-pgp
are doing it, and they all seem to do it this way instead.

the sbt-pgp version upgrade might not actually be necessary here, but
seems good to include regardless