### PR TITLE
Exception while trying to resolve link for github that contains placeholders

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -360,7 +360,7 @@ case class SnipDirective(page: Page, variables: Map[String, String])
       new VerbatimGroupNode(text, lang, group, node.attributes.classes).accept(visitor)
       if (variables.contains(GitHubResolver.baseUrl) &&
         variables.getOrElse(SnipDirective.showGithubLinks, "false") == "true") {
-        val p = resolvePath(page, file.getAbsolutePath, labels.headOption).base.normalize.toString
+        val p = resolvePath(page, Path.toUnixStyleRootPath(file.getAbsolutePath), labels.headOption).base.normalize.toString
         new ExpLinkNode("", p, new TextNode("Full source at GitHub")).accept(visitor)
       }
     } catch {

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -281,9 +281,9 @@ trait GitHubResolver {
       case Some(dir) => new File(dir)
     }
     val file = path match {
-      case p if p.startsWith(root.getAbsolutePath) => new File(p)
-      case p if p.startsWith("/")                  => new File(root, path.drop(1))
-      case p                                       => new File(page.file.getParentFile, path)
+      case p if p.startsWith(Path.toUnixStyleRootPath(root.getAbsolutePath)) => new File(p)
+      case p if p.startsWith("/")                                            => new File(root, path.drop(1))
+      case p                                                                 => new File(page.file.getParentFile, path)
     }
     val labelFragment =
       for {

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Snippet.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Snippet.scala
@@ -24,8 +24,7 @@ object Snippet {
 
   class SnippetException(message: String) extends RuntimeException(message)
 
-  def apply(propPrefix: String, source: String, labels: Seq[String], page: Page, variables: Map[String, String]): (String, String) = {
-    val file = resolveFile(propPrefix, source, page, variables)
+  def apply(file: File, labels: Seq[String]): (String, String) = {
     (extract(file, labels), language(file))
   }
 
@@ -43,15 +42,6 @@ object Snippet {
   }
 
   type Line = (Int, String)
-
-  private def resolveFile(propPrefix: String, source: String, page: Page, variables: Map[String, String]): File = {
-    if (source startsWith "$") {
-      val baseKey = source.drop(1).takeWhile(_ != '$')
-      val base = new File(PropertyUrl(s"$propPrefix.$baseKey.base_dir", variables.get).base.trim)
-      val effectiveBase = if (base.isAbsolute) base else new File(page.file.getParentFile, base.toString)
-      new File(effectiveBase, source.drop(baseKey.length + 2))
-    } else new File(page.file.getParentFile, source)
-  }
 
   private def extractState(file: File, label: String): ExtractionState = {
     if (!verifyLabel(label)) throw new SnippetException(s"Label [$label] for [$file] contains illegal characters. " +

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/SnipDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/SnipDirectiveSpec.scala
@@ -16,6 +16,8 @@
 
 package com.lightbend.paradox.markdown
 
+import java.io.File
+
 import com.lightbend.paradox.tree.Tree.Location
 
 class SnipDirectiveSpec extends MarkdownBaseSpec {
@@ -94,7 +96,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
   it should "add link to source" in {
     implicit val context = writerContextWithProperties(
       "github.base_url" -> "https://github.com/lightbend/paradox/tree/v0.2.1",
-      "github.root.base_dir" -> ".",
+      "github.root.base_dir" -> new File(".").getAbsoluteFile.getParent,
       "snip.github_link" -> "true")
 
     markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #example }""") shouldEqual html(
@@ -107,10 +109,27 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
         |<a href="https://github.com/lightbend/paradox/tree/v0.2.1/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala#L28-L30">Full source at GitHub</a>""")
   }
 
+  it should "add link to source with placeholders" in {
+    implicit val context = writerContextWithProperties(
+      "github.base_url" -> "https://github.com/lightbend/paradox/tree/v0.2.1",
+      "github.root.base_dir" -> new File(".").getAbsoluteFile.getParent,
+      "snip.github_link" -> "true",
+      "snip.test.base_dir" -> "tests/src/test/scala/com/lightbend/paradox/markdown")
+
+    markdown("""@@snip[example.scala]($test$/example.scala) { #example }""") shouldEqual html(
+      """<pre class="prettyprint">
+        |<code class="language-scala">
+        |object example extends App {
+        |  println("Hello, World!")
+        |}</code>
+        |</pre>
+        |<a href="https://github.com/lightbend/paradox/tree/v0.2.1/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala#L28-L30">Full source at GitHub</a>""")
+  }
+
   it should "not link to source if config says so" in {
     implicit val context = writerContextWithProperties(
       "github.base_url" -> "https://github.com/lightbend/paradox/tree/v0.2.1",
-      "github.root.base_dir" -> ".",
+      "github.root.base_dir" -> new File(".").getAbsoluteFile.getParent,
       "snip.github_link" -> "false")
 
     markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #example }""") shouldEqual html(


### PR DESCRIPTION
There is currently a regression in just released `0.3.4` where an exception is being thrown when a snippet path contains a placeholder. A workaround is to disable github links wtih `"snip.github_link" -> "false"` in `paradoxProperties`.