### PR TITLE
Bump sbt-paradox version to 0.3.4

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,7 +20,7 @@ addSbtPlugin("de.heikoseeberger"     % "sbt-header"      % "5.0.0")
 addSbtPlugin("org.foundweekends"     % "sbt-bintray"     % "0.5.1")
 addSbtPlugin("org.xerial.sbt"        % "sbt-sonatype"    % "2.0")
 addSbtPlugin("com.jsuereth"          % "sbt-pgp"         % "1.1.0")
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox"     % "0.3.2")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox"     % "0.3.4")
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 


### PR DESCRIPTION
Needed to show the multi-dependency example (#202) in the doc site correctly.