### PR TITLE
Improve github.base_url derivation

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -259,7 +259,6 @@ case class JavadocDirective(page: Page, variables: Map[String, String])
 
 object GitHubResolver {
   val baseUrl = "github.base_url"
-
 }
 
 trait GitHubResolver {

--- a/plugin/src/sbt-test/paradox/github/build.sbt
+++ b/plugin/src/sbt-test/paradox/github/build.sbt
@@ -1,9 +1,18 @@
+// setting values through custom keys because scripted tests do not like strings in 'set' statements
+val scmInfoTree = SettingKey[Some[ScmInfo]]("scmInfoTree")
+val scmInfoProject = SettingKey[Some[ScmInfo]]("scmInfoProject")
+val taggedVersion = SettingKey[String]("taggedVersion")
+val githubBaseUrlEntry = SettingKey[(String, String)]("githubBaseUrlEntry")
+
 lazy val root = (project in file("."))
 
 lazy val docs = (project in file("docs")).
   enablePlugins(ParadoxPlugin).
   settings(
     paradoxTheme := None,
-    paradoxProperties in Compile +=
-      ("github.base_url" -> "https://github.com/lightbend/paradox/tree/v0.2.1")
+
+    scmInfoTree := Some(ScmInfo(url("https://github.com/lightbend/paradox/tree/v0.2.1"), "git@github.com:lightbend/paradox.git")),
+    scmInfoProject := Some(ScmInfo(url("https://github.com/lightbend/paradox"), "git@github.com:lightbend/paradox.git")),
+    taggedVersion := "0.2.1",
+    githubBaseUrlEntry := ("github.base_url" -> "https://github.com/lightbend/paradox/tree/v0.2.1")
   )

--- a/plugin/src/sbt-test/paradox/github/expected/github-master.html
+++ b/plugin/src/sbt-test/paradox/github/expected/github-master.html
@@ -1,0 +1,12 @@
+<p><a href="https://github.com/lightbend/paradox/tree/master/docs/src/test/scala/GitHub.scala#L2-L19">multiple</a></p>
+<p><a href="https://github.com/lightbend/paradox/tree/master/docs/src/test/scala/GitHub.scala#L2-L19">multiple</a></p>
+<p><a href="https://github.com/lightbend/paradox/tree/master/docs/src/test/scala/GitHub.scala#L2-L19">absolute</a></p>
+<p><a href="https://github.com/lightbend/paradox/tree/master/docs/src/test/scala/GitHub.scala#L2-L19">relative</a></p>
+<p><a href="https://github.com/lightbend/paradox/tree/master/docs/src/test/scala/GitHub.scala#L4">single</a></p>
+<p><a href="https://github.com/lightbend/paradox/tree/master/docs/src/test/scala/GitHub.scala#L4">single</a></p>
+<p><a href="https://github.com/lightbend/paradox/tree/master/docs/src/test/scala/GitHub.scala#L4">absolute</a></p>
+<p><a href="https://github.com/lightbend/paradox/tree/master/docs/src/test/scala/GitHub.scala#L4">relative</a></p>
+<p><a href="https://github.com/lightbend/paradox/tree/master/docs/src/test/scala/GitHub.scala#L12-L17">single</a></p>
+<p><a href="https://github.com/lightbend/paradox/tree/master/docs/src/test/scala/GitHub.scala#L12-L17">single</a></p>
+<p><a href="https://github.com/lightbend/paradox/tree/master/docs/src/test/scala/GitHub.scala#L12-L17">absolute</a></p>
+<p><a href="https://github.com/lightbend/paradox/tree/master/docs/src/test/scala/GitHub.scala#L12-L17">relative</a></p>

--- a/plugin/src/sbt-test/paradox/github/test
+++ b/plugin/src/sbt-test/paradox/github/test
@@ -1,26 +1,26 @@
 # should work with tree url in scm info
 > docs/clean
-> set docs/scmInfo := (docs/scmInfoTree).value
+> set scmInfo in docs := (scmInfoTree in docs).value
 > docs/paradox
 $ must-mirror docs/target/paradox/site/main/github.html expected/github.html
 
 # should work with project url in scm info and not snapshot
 > docs/clean
-> set docs/scmInfo := (docs/scmInfoProject).value
-> set docs/version := (docs/taggedVersion).value
-> set docs/isSnapshot := false
+> set scmInfo in docs := (scmInfoProject in docs).value
+> set version in docs := (taggedVersion in docs).value
+> set isSnapshot in docs := false
 > docs/paradox
 $ must-mirror docs/target/paradox/site/main/github.html expected/github.html
 
 # should work with snapshot
 > docs/clean
-> set docs/isSnapshot := true
+> set isSnapshot in docs := true
 > docs/paradox
 $ must-mirror docs/target/paradox/site/main/github.html expected/github-master.html
 
 # should work with base_url set explicitly
 > docs/clean
-> set docs/scmInfo := None
-> set docs/Compile/paradoxProperties += (docs/githubBaseUrlEntry).value
+> set scmInfo in docs := None
+> set paradoxProperties in docs in Compile += (githubBaseUrlEntry in docs).value
 > docs/paradox
 $ must-mirror docs/target/paradox/site/main/github.html expected/github.html

--- a/plugin/src/sbt-test/paradox/github/test
+++ b/plugin/src/sbt-test/paradox/github/test
@@ -1,3 +1,26 @@
+# should work with tree url in scm info
+> docs/clean
+> set docs/scmInfo := (docs/scmInfoTree).value
 > docs/paradox
+$ must-mirror docs/target/paradox/site/main/github.html expected/github.html
 
+# should work with project url in scm info and not snapshot
+> docs/clean
+> set docs/scmInfo := (docs/scmInfoProject).value
+> set docs/version := (docs/taggedVersion).value
+> set docs/isSnapshot := false
+> docs/paradox
+$ must-mirror docs/target/paradox/site/main/github.html expected/github.html
+
+# should work with snapshot
+> docs/clean
+> set docs/isSnapshot := true
+> docs/paradox
+$ must-mirror docs/target/paradox/site/main/github.html expected/github-master.html
+
+# should work with base_url set explicitly
+> docs/clean
+> set docs/scmInfo := None
+> set docs/Compile/paradoxProperties += (docs/githubBaseUrlEntry).value
+> docs/paradox
 $ must-mirror docs/target/paradox/site/main/github.html expected/github.html

--- a/plugin/src/sbt-test/paradox/parameterized-links/expected/github.html
+++ b/plugin/src/sbt-test/paradox/parameterized-links/expected/github.html
@@ -1,3 +1,3 @@
 <p>Issue <a href="https://github.com/lightbend/paradox/issues/1">#1</a> was fixed in commit <a href="https://github.com/lightbend/paradox/commit/83986f9">83986f9</a>.</p>
 <p>PR <a href="https://github.com/akka/akka-http/issues/292">#292</a> merged in <a href="https://github.com/akka/akka-http/commit/cbbc99465d90c8c08aada353b767a21a51454cc0">cbbc994</a>.</p>
-<p>See <a href="https://github.com/lightbend/paradox/tree/master/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala">ParadoxProcessor.scala</a> and <a href="https://github.com/lightbend/paradox/tree/master/docs/index.png">index.png</a>.</p>
+<p>See <a href="https://github.com/lightbend/paradox/tree/v0.1.0/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala">ParadoxProcessor.scala</a> and <a href="https://github.com/lightbend/paradox/tree/v0.1.0/docs/index.png">index.png</a>.</p>

--- a/plugin/src/sbt-test/paradox/site/build.sbt
+++ b/plugin/src/sbt-test/paradox/site/build.sbt
@@ -2,6 +2,7 @@ lazy val docs = project
   .in(file("."))
   .enablePlugins(ParadoxPlugin)
   .settings(
+    version := "0.1-SNAPSHOT",
     name := "Paradox Test",
     paradoxLeadingBreadcrumbs := List("Alphabet" -> "https://abc.xyz/", "Google" -> "https://www.google.com"),
     paradoxTheme := None


### PR DESCRIPTION
This PR improves automatic `github.base_url` property derivation. If a project is on a non-snapshot version, it will set `github.base_url` to `.../tree/v<version>` instead of always to `.../tree/master`.