### PR TITLE
Add class on the link to the full source on GitHub

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -365,7 +365,7 @@ case class SnipDirective(page: Page, variables: Map[String, String])
       if (variables.contains(GitHubResolver.baseUrl) &&
         variables.getOrElse(SnipDirective.showGithubLinks, "false") == "true") {
         val p = resolvePath(page, Path.toUnixStyleRootPath(file.getAbsolutePath), labels.headOption).base.normalize.toString
-        new ExpLinkNode("", p, new TextNode("Full source at GitHub")).accept(visitor)
+        new ClassyLinkNode(p, "snippet-full-source github", new TextNode("Full source at GitHub")).accept(visitor)
       }
     } catch {
       case e: FileNotFoundException =>

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/SnipDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/SnipDirectiveSpec.scala
@@ -119,7 +119,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
         |  println("Hello, World!")
         |}</code>
         |</pre>
-        |<a href="https://github.com/lightbend/paradox/tree/v0.2.1/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala#L28-L30">Full source at GitHub</a>""")
+        |<a href="https://github.com/lightbend/paradox/tree/v0.2.1/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala#L28-L30" class="snippet-full-source github">Full source at GitHub</a>""")
   }
 
   it should "add link to source with placeholders" in {
@@ -136,7 +136,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
         |  println("Hello, World!")
         |}</code>
         |</pre>
-        |<a href="https://github.com/lightbend/paradox/tree/v0.2.1/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala#L28-L30">Full source at GitHub</a>""")
+        |<a href="https://github.com/lightbend/paradox/tree/v0.2.1/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala#L28-L30" class="snippet-full-source github">Full source at GitHub</a>""")
   }
 
   it should "not link to source if config says so" in {


### PR DESCRIPTION
Open for ideas of better naming.

The main motivation is that it would be nice to be able to style those links. Example from the Material theme:

<img width="781" alt="screen shot 2018-09-11 at 12 12 28" src="https://user-images.githubusercontent.com/8417/45372885-fe043300-b5bb-11e8-9db2-340ef4945f8b.png">
