### PR TITLE
Replace Oracle JDK 10 with Open JDK 11; Scala 2.12.7; sbt 1.2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
       jdk: oraclejdk8
 
     - script: sbt verify
-      jdk: oraclejdk10
+      jdk: openjdk11
 
     - stage: publish
       script: sbt ci-release

--- a/build.sbt
+++ b/build.sbt
@@ -20,8 +20,8 @@ import java.lang.management.ManagementFactory
 inThisBuild(List(
   organization := "com.lightbend.paradox",
   licenses += "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"),
-  scalaVersion := "2.12.6",
-  crossScalaVersions := Seq("2.10.7", "2.12.6"),
+  scalaVersion := "2.12.7",
+  crossScalaVersions := Seq("2.10.7", "2.12.7"),
   organizationName := "lightbend",
   organizationHomepage := Some(url("https://lightbend.com/")),
   homepage := Some(url("https://github.com/lightbend/paradox")),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.6


### PR DESCRIPTION
Travis doesn't allow Oracle JDK 10 anymore.
```
oraclejdk10 is deprecated. See https://www.oracle.com/technetwork/java/javase/eol-135779.html for more details. Consider using openjdk10 instead.
```