### PR TITLE
fix imgs not found in `organizing-pages`

### DIFF
--- a/docs/src/main/paradox/directives/organizing-pages.md
+++ b/docs/src/main/paradox/directives/organizing-pages.md
@@ -34,7 +34,7 @@ Inside `setup/index.md` can list its own child pages as follows:
 
 Paradox will walk through these indices and create a hierarchical navigation sidebar:
 
-![index](img/index.png)
+![index](../img/index.png)
 
 Similar to `@ref`, the source document on Github will link correctly the other sources.
 
@@ -51,4 +51,4 @@ The `@@toc` block is used to include a table of content with arbitrary depth.
 
 This will render the page names (first header), and the second headers.
 
-![toc](img/toc.png)
+![toc](../img/toc.png)


### PR DESCRIPTION
imgs not found in [organizing-pages](https://developer.lightbend.com/docs/paradox/current/directives/organizing-pages.html)