### PR TITLE
Implemented markdown includes

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
+++ b/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
@@ -62,7 +62,7 @@ class ParadoxProcessor(reader: Reader = new Reader, writer: Writer = new Writer)
         val page = loc.tree.label
         val pageProperties = properties ++ page.properties.get
         val currentMapping = Path.generateTargetFile(Path.relativeLocalPath(page.rootSrcPage, page.file.getPath), globalPageMappings)
-        val writerContext = Writer.Context(loc, paths, currentMapping, sourceSuffix, targetSuffix, groups, pageProperties)
+        val writerContext = Writer.Context(loc, paths, reader, writer, currentMapping, sourceSuffix, targetSuffix, groups, pageProperties)
         val pageContext = PageContents(leadingBreadcrumbs, groups, loc, writer, writerContext, navToc, pageToc)
         val outputFile = new File(outputDirectory, page.path)
         outputFile.getParentFile.mkdirs

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
@@ -143,6 +143,15 @@ object Page {
     val DefaultOutMdIndicator = "out"
     val DefaultLayoutMdIndicator = "layout"
   }
+
+  /**
+   * Create an included page.
+   */
+  def included(file: File, includeFilePath: String, includedIn: Page, markdown: RootNode): Page = {
+    val rootSrcPage = Path.relativeRootPath(file, includeFilePath)
+    val h1 = Header(includedIn.path, new SpecialTextNode(includedIn.path), None)
+    Page(file, includedIn.path, rootSrcPage, h1.label, h1, Nil, markdown, h1.group, includedIn.properties)
+  }
 }
 
 /**

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
@@ -19,7 +19,8 @@ package com.lightbend.paradox.markdown
 import com.lightbend.paradox.tree.Tree.Location
 import org.pegdown.plugins.ToHtmlSerializerPlugin
 import org.pegdown.ast.{ ExpImageNode, Node, RefImageNode, RootNode }
-import org.pegdown.{ LinkRenderer, ToHtmlSerializer, VerbatimSerializer }
+import org.pegdown.{ LinkRenderer, Printer, ToHtmlSerializer, VerbatimSerializer }
+
 import scala.collection.JavaConverters._
 
 /**
@@ -95,6 +96,8 @@ object Writer {
   case class Context(
       location:     Location[Page],
       paths:        Set[String],
+      reader:       Reader,
+      writer:       Writer,
       pageMappings: String => String         = Path.replaceExtension(DefaultSourceSuffix, DefaultTargetSuffix),
       sourceSuffix: String                   = DefaultSourceSuffix,
       targetSuffix: String                   = DefaultTargetSuffix,
@@ -133,7 +136,8 @@ object Writer {
     context => WrapDirective("div"),
     context => InlineWrapDirective("span"),
     context => InlineGroupDirective(context.groups.values.flatten.map(_.toLowerCase).toSeq),
-    context => DependencyDirective(context.properties)
+    context => DependencyDirective(context.properties),
+    context => IncludeDirective(context)
   )
 
   class DefaultLinkRenderer(context: Context) extends LinkRenderer {

--- a/docs/src/main/paradox/directives/directives-alphabetically.md
+++ b/docs/src/main/paradox/directives/directives-alphabetically.md
@@ -4,6 +4,7 @@
  * @ref[`@@@div`](css-friendliness.md#div)
  * @ref[`@extref`](linking.md#extref-directive)
  * @ref[`@github`](linking.md#github-directive)
+ * @ref[`@@include`](includes.md)
  * @ref[`@@@index`](organizing-pages.md#index-container)
  * @ref[`@javadoc`](linking.md#javadoc)
  * @ref[`@@@note`](callouts.md#note-callout)

--- a/docs/src/main/paradox/directives/includes.md
+++ b/docs/src/main/paradox/directives/includes.md
@@ -1,0 +1,55 @@
+Markdown file inclusion
+-----------------------
+
+### @@include block
+
+The `@@include` block is used to include full or partial markdown files rendered into this file.
+
+```markdown
+@@include[my-file.md](includes/my-file.md)
+```
+
+This will load and render `includes/my-file.md` at the location of the include.
+
+To include partial files, snippet identifiers can be used:
+
+```markdown
+@@include[my-file.md](includes/my-file.md) { #my-section }
+```
+
+Then, inside `includes/my-file.md`, mark the section using the `#my-section` inside comments as follows:
+
+```markdown
+<!--- #my-section --->
+Only this part of the markdown file will be included.
+<!--- #my-section --->
+```
+
+Note that the file name label optional and not used, however it is recommended that you include it to ensure that
+other markdown renderers that don't support the include directive, such as GitHub, will render the include as a 
+link to the included file.
+
+### `include.*.base_dir`
+
+In order to specify your include source paths off certain base directories you can define placeholders
+either in the page's front matter or globally like this (for example):
+
+```sbt
+paradoxProperties in Compile ++= Map(
+  "include.test.base_dir" -> s"${(sourceDirectory in Test).value}/paradox"
+)
+```
+
+You can then refer to one of the defined base directories by starting the include's target path with `$placeholder$`,
+for example:
+
+```markdown
+@@include[test-docs.md]($test$/test-docs.md)
+```
+
+If a placeholder directory is relative it'll be based of the path of the respective page it is used in.
+Also, *paradox* always auto-defines the placeholder `$root$` to denote the absolute path of the sbt (sub)project's 
+root directory.
+
+**Note**: Using this feature will not allow GitHub to follow the include links correctly on the web UI.
+

--- a/docs/src/main/paradox/directives/index.md
+++ b/docs/src/main/paradox/directives/index.md
@@ -11,6 +11,7 @@ which signifies a directive usage. Depending on the scope of the directive you w
  * [Index and Table Of Contents Directives](organizing-pages.md)
  * [Linking Directives](linking.md)
  * [Snippet Directives](snippets.md)
+ * [Include Directives](includes.md)
  * [Fiddle Directives](fiddles.md)
  * [Callout Directives](callouts.md)
  * [Variable Substitution Directives](vars.md)

--- a/testkit/src/main/scala/com/lightbend/paradox/markdown/MarkdownTestkit.scala
+++ b/testkit/src/main/scala/com/lightbend/paradox/markdown/MarkdownTestkit.scala
@@ -83,6 +83,8 @@ abstract class MarkdownTestkit {
     Writer.Context(
       location,
       Page.allPaths(List(location.root.tree)).toSet,
+      markdownReader,
+      markdownWriter,
       groups = Map("Language" -> Seq("Scala", "Java"))
     )
   }

--- a/tests/src/test/resources/include-nested.md
+++ b/tests/src/test/resources/include-nested.md
@@ -1,0 +1,3 @@
+**This should demonstrate nested includes**
+
+@@include(include.md)

--- a/tests/src/test/resources/include-snip.md
+++ b/tests/src/test/resources/include-snip.md
@@ -1,0 +1,5 @@
+## A partial include
+
+<!--- #section --->
+Only this part should be included.
+<!--- #section --->

--- a/tests/src/test/resources/include.md
+++ b/tests/src/test/resources/include.md
@@ -1,0 +1,3 @@
+**An include**
+
+This file should be included by IncludeDirectiveSpec

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/IncludeDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/IncludeDirectiveSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.paradox.markdown
+
+import com.lightbend.paradox.tree.Tree.Location
+
+class IncludeDirectiveSpec extends MarkdownBaseSpec {
+
+  val testProperties = Map("version" -> "1.2.3")
+
+  implicit val context: Location[Page] => Writer.Context = { loc =>
+    writerContext(loc).copy(properties = testProperties)
+  }
+
+  "The `include` directive" should "include and render full markdown files" in {
+    markdown("""@@include(tests/src/test/resources/include.md)""") shouldEqual html("""
+      |<p><strong>An include</strong></p>
+      |<p>This file should be included by IncludeDirectiveSpec</p>""")
+  }
+
+  it should "include markdown files with a label" in {
+    markdown("""@@include[include.md](tests/src/test/resources/include.md)""") shouldEqual html("""
+      |<p><strong>An include</strong></p>
+      |<p>This file should be included by IncludeDirectiveSpec</p>""")
+  }
+
+  it should "include partial files when specified" in {
+    markdown("""@@include(tests/src/test/resources/include-snip.md) { #section } """) shouldEqual html("""
+      |<p>Only this part should be included.</p>""")
+  }
+
+  it should "include nested snippets rendered in the context of the snippet" in {
+    markdown("""@@include(tests/src/test/resources/include-nested.md)""") shouldEqual html("""
+      |<p><strong>This should demonstrate nested includes</strong></p>
+      |<p><strong>An include</strong></p>
+      |<p>This file should be included by IncludeDirectiveSpec</p>""")
+  }
+
+}


### PR DESCRIPTION
Fixes #195

Implemented markdown includes. It's very similar to snips, except that instead of outputting the content in a verbatim node that then gets rendered, it parses the content with the reader and then writes it
with a writer.

A new context is created for the writer to allow the included markdown file to include other markdown files and code snippets relative to itself. However, not a lot else about the context is modified, for example, custom properties for the included page aren't read. This might be desirable in some cases, and indesirable in others, not sure, I think it's best to wait and see what issues people report with it to see what other context should be modified.