### PR TITLE
Support variable substitution in links

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
+++ b/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
@@ -49,7 +49,7 @@ class ParadoxProcessor(reader: Reader = new Reader, writer: Writer = new Writer)
     errorListener:      STErrorListener): Seq[(File, String)] = {
     require(!groups.values.flatten.map(_.toLowerCase).groupBy(identity).values.exists(_.size > 1), "Group names may not overlap")
 
-    val pages = parsePages(mappings, Path.replaceSuffix(sourceSuffix, targetSuffix))
+    val pages = parsePages(mappings, Path.replaceSuffix(sourceSuffix, targetSuffix), properties)
     val paths = Page.allPaths(pages).toSet
     val globalPageMappings = rootPageMappings(pages)
 
@@ -174,8 +174,8 @@ class ParadoxProcessor(reader: Reader = new Reader, writer: Writer = new Writer)
   /**
    * Parse markdown files (with paths) into a forest of linked pages.
    */
-  def parsePages(mappings: Seq[(File, String)], convertPath: String => String): Forest[Page] = {
-    Page.forest(parseMarkdown(mappings), convertPath)
+  def parsePages(mappings: Seq[(File, String)], convertPath: String => String, properties: Map[String, String]): Forest[Page] = {
+    Page.forest(parseMarkdown(mappings), convertPath, properties)
   }
 
   /**

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
@@ -80,8 +80,8 @@ object Page {
   /**
    * Convert parsed markdown pages into a linked forest of Page objects.
    */
-  def forest(parsed: Seq[(File, String, RootNode, Map[String, String])], convertPath: String => String): Forest[Page] = {
-    Index.pages(parsed) map (_ map convertPage(convertPath))
+  def forest(parsed: Seq[(File, String, RootNode, Map[String, String])], convertPath: String => String, properties: Map[String, String]): Forest[Page] = {
+    Index.pages(parsed, properties) map (_ map convertPage(convertPath))
   }
 
   /**

--- a/testkit/src/main/scala/com/lightbend/paradox/markdown/MarkdownTestkit.scala
+++ b/testkit/src/main/scala/com/lightbend/paradox/markdown/MarkdownTestkit.scala
@@ -76,8 +76,10 @@ abstract class MarkdownTestkit {
   }
 
   def writerContextWithProperties(properties: (String, String)*): Location[Page] => Writer.Context = { location =>
-    writerContext(location).copy(properties = properties.toMap)
+    writerContext(location).copy(properties = globalProperties ++ properties.toMap)
   }
+
+  val globalProperties: Map[String, String] = Map()
 
   def writerContext(location: Location[Page]): Writer.Context = {
     Writer.Context(
@@ -85,7 +87,8 @@ abstract class MarkdownTestkit {
       Page.allPaths(List(location.root.tree)).toSet,
       markdownReader,
       markdownWriter,
-      groups = Map("Language" -> Seq("Scala", "Java"))
+      groups = Map("Language" -> Seq("Scala", "Java")),
+      properties = globalProperties
     )
   }
 
@@ -95,7 +98,7 @@ abstract class MarkdownTestkit {
         val frontin = Frontin(prepare(text))
         (new File(path), path, markdownReader.read(frontin.body), frontin.header)
     }
-    Page.forest(parsed, Path.replaceSuffix(Writer.DefaultSourceSuffix, Writer.DefaultTargetSuffix))
+    Page.forest(parsed, Path.replaceSuffix(Writer.DefaultSourceSuffix, Writer.DefaultTargetSuffix), globalProperties)
   }
 
   def html(text: String): String = {

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/IndexSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/IndexSpec.scala
@@ -20,6 +20,8 @@ import com.lightbend.paradox.tree.Tree.Forest
 
 class IndexSpec extends MarkdownBaseSpec {
 
+  override val globalProperties = Map("platform" -> "openshift")
+
   "Index" should "create header tree" in {
     indexed(
       "a.md" -> """
@@ -131,6 +133,22 @@ class IndexSpec extends MarkdownBaseSpec {
         |      - f.html
         |      - g.html
         |  - h.html
+      """)
+  }
+
+  it should "substitute variables in links" in {
+    indexed(
+      "a.md" -> """
+        |# A
+        |@@@ index
+        |* [platform]($platform$.md)
+        |@@@
+      """,
+      "openshift.md" -> "# OpenShift"
+    ) shouldEqual index(
+        """
+        |- a.html
+        |  - openshift.html
       """)
   }
 

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/RefDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/RefDirectiveSpec.scala
@@ -18,6 +18,8 @@ package com.lightbend.paradox.markdown
 
 class RefDirectiveSpec extends MarkdownBaseSpec {
 
+  private implicit val context = writerContextWithProperties("page.variable" -> "page")
+
   def testMarkdown(text: String, pagePath: String = "page.md", testPath: String = "test.md"): Map[String, String] = markdownPages(
     pagePath -> s"""
       |@@@ index
@@ -93,4 +95,9 @@ class RefDirectiveSpec extends MarkdownBaseSpec {
       markdown("@ref[Page][123]")
     } should have message "Undefined reference key [123] in [test.html]"
   }
+
+  it should "support variables in link paths" in {
+    testMarkdown("@ref[Page]($page.variable$.md)") shouldEqual testHtml("""<p><a href="page.html">Page</a></p>""")
+  }
+
 }

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/VarDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/VarDirectiveSpec.scala
@@ -79,4 +79,15 @@ class VarDirectiveSpec extends MarkdownBaseSpec {
   it should "parse but ignore legacy directive source and attributes" in {
     markdown("The @var[version] (xxx) { .var a=1 } version.") shouldEqual html("<p>The 1.2.3 version.</p>")
   }
+
+  it should "work in explicit link URLs" in {
+    markdown("[Link](http://example.com/$version$/)") shouldEqual html("""<p><a href="http://example.com/1.2.3/">Link</a></p>""")
+    markdown("[Link](http://example.com/$scala.version$/)") shouldEqual html("""<p><a href="http://example.com/2.12.6/">Link</a></p>""")
+  }
+
+  it should "work in reference link URLs" in {
+    markdown("[Link][1]\n\n[1]: http://example.com/$version$/") shouldEqual html("""<p><a href="http://example.com/1.2.3/">Link</a></p>""")
+    markdown("[Link][1]\n\n[1]: http://example.com/$scala.version$/") shouldEqual html("""<p><a href="http://example.com/2.12.6/">Link</a></p>""")
+  }
+
 }


### PR DESCRIPTION
Fixes #178

Since URLs in links are not parsed as inline markdown (unlike link labels), our regular support for variable substitution doesn't work in them. To solve, on a case by case basis, we can substitute specific strings with variables. This has been applied to three cases:

* Explicit markdown links
* Reference markdown links
* Links inside indexes
* Most source directives (eg, ref, snip, include)