### PR TITLE
Improved includes

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
+++ b/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
@@ -218,7 +218,10 @@ class ParadoxProcessor(reader: Reader = new Reader, writer: Writer = new Writer)
           throw IncludeDirective.IncludeFormatException(snippetLang)
         }
         val includedRoot = parseAndProcessMarkdown(includeFile, text, properties ++ frontin.header)
-        newChildren.add(IncludeNode(includedRoot, includeFile, source))
+        val includeNode = IncludeNode(includedRoot, includeFile, source)
+        includeNode.setStartIndex(include.getStartIndex)
+        includeNode.setEndIndex(include.getEndIndex)
+        newChildren.add(includeNode)
 
       case other => newChildren.add(other)
     }

--- a/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
+++ b/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
@@ -211,7 +211,9 @@ class ParadoxProcessor(reader: Reader = new Reader, writer: Writer = new Writer)
         }
         val includeFile = SourceDirective.resolveFile("include", source, file, properties)
         val frontin = Frontin(includeFile)
-        val filterLabels = include.attributes.booleanValue("filterLabels", false)
+        val filterLabels = include.attributes.booleanValue(
+          "filterLabels",
+          properties.get("include.filterLabels").exists(_ == "true"))
         val (text, snippetLang) = Snippet(includeFile, labels, filterLabels)
         // I guess we could support multiple markup languages in future...
         if (snippetLang != "md" && snippetLang != "markdown") {

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -364,7 +364,7 @@ case class SnipDirective(page: Page, variables: Map[String, String])
     try {
       val labels = node.attributes.values("identifier").asScala
       val source = resolvedSource(node, page)
-      val filterLabels = node.attributes.booleanValue("filterLabels", true)
+      val filterLabels = node.attributes.booleanValue("filterLabels", variables.get("snip.filterLabels").forall(_ == "true"))
       val file = resolveFile("snip", source, page, variables)
       val (text, snippetLang) = Snippet(file, labels, filterLabels)
       val lang = Option(node.attributes.value("type")).getOrElse(snippetLang)
@@ -417,7 +417,7 @@ case class FiddleDirective(page: Page, variables: Map[String, String])
 
       val source = resolvedSource(node, page)
       val file = resolveFile("fiddle", source, page, variables)
-      val filterLabels = node.attributes.booleanValue("filterLabels", true)
+      val filterLabels = node.attributes.booleanValue("filterLabels", variables.get("fiddle.filterLabels").forall(_ == "true"))
       val (code, _) = Snippet(file, labels, filterLabels)
 
       printer.println.print(s"""

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -450,7 +450,7 @@ object FiddleDirective {
  * Placeholder to insert a serialized table of contents, using the page and header trees.
  * Depth and whether to include pages or headers can be specified in directive attributes.
  */
-case class TocDirective(location: Location[Page]) extends LeafBlockDirective("toc") {
+case class TocDirective(location: Location[Page], includeIndexes: List[Int]) extends LeafBlockDirective("toc") {
   def render(node: DirectiveNode, visitor: Visitor, printer: Printer): Unit = {
     val classes = node.attributes.classesString
     val depth = node.attributes.intValue("depth", 6)
@@ -459,7 +459,7 @@ case class TocDirective(location: Location[Page]) extends LeafBlockDirective("to
     val ordered = node.attributes.booleanValue("ordered", false)
     val toc = new TableOfContents(pages, headers, ordered, depth)
     printer.println.print(s"""<div class="toc $classes">""")
-    toc.markdown(location, node.getStartIndex).accept(visitor)
+    toc.markdown(location, node.getStartIndex, includeIndexes).accept(visitor)
     printer.println.print("</div>")
   }
 }

--- a/core/src/main/scala/com/lightbend/paradox/markdown/IncludeNode.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/IncludeNode.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.paradox.markdown
+
+import java.io.File
+import java.util
+
+import com.lightbend.paradox.markdown.Writer.Context
+import com.lightbend.paradox.tree.Tree
+import com.lightbend.paradox.tree.Tree.Location
+import org.pegdown.Printer
+import org.pegdown.ast.{ AbstractNode, Node, RootNode, Visitor }
+import org.pegdown.plugins.ToHtmlSerializerPlugin
+
+case class IncludeNode(included: RootNode, includedFrom: File, includedFromPath: String) extends AbstractNode {
+  override def accept(visitor: Visitor): Unit = visitor.visit(this)
+  override def getChildren: util.List[Node] = included.getChildren
+}
+
+class IncludeNodeSerializer(context: Context) extends ToHtmlSerializerPlugin {
+  override def visit(node: Node, visitor: Visitor, printer: Printer): Boolean = node match {
+    case IncludeNode(included, includedFrom, includedFromPath) =>
+      // This location has no forest around it... which probably means that things like toc and navigation can't
+      // be rendered inside snippets, which I'm ok with.
+      val newLocation = Location(Tree.leaf(Page.included(includedFrom, includedFromPath,
+        context.location.tree.label, included)), Nil, Nil, Nil)
+      printer.print(context.writer.writeContent(included, context.copy(location = newLocation)))
+      true
+    case _ => false
+  }
+}

--- a/core/src/main/scala/com/lightbend/paradox/markdown/IncludeNode.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/IncludeNode.scala
@@ -33,12 +33,14 @@ case class IncludeNode(included: RootNode, includedFrom: File, includedFromPath:
 
 class IncludeNodeSerializer(context: Context) extends ToHtmlSerializerPlugin {
   override def visit(node: Node, visitor: Visitor, printer: Printer): Boolean = node match {
-    case IncludeNode(included, includedFrom, includedFromPath) =>
+    case include @ IncludeNode(included, includedFrom, includedFromPath) =>
       // This location has no forest around it... which probably means that things like toc and navigation can't
       // be rendered inside snippets, which I'm ok with.
       val newLocation = Location(Tree.leaf(Page.included(includedFrom, includedFromPath,
-        context.location.tree.label, included)), Nil, Nil, Nil)
-      printer.print(context.writer.writeContent(included, context.copy(location = newLocation)))
+        context.location.tree.label, included)), context.location.lefts, context.location.rights, context.location.parents)
+      printer.print(context.writer.writeContent(included, context.copy(
+        location = newLocation,
+        includeIndexes = context.includeIndexes :+ include.getStartIndex)))
       true
     case _ => false
   }

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Index.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Index.scala
@@ -65,6 +65,8 @@ object Index {
         // if so maybe move that cast to DirectiveNode
         val newGroup = node.attributes.classes().asScala.find(_.startsWith("group-")).map(_.substring("group-".size))
         headerRefs(node.contentsNode.asInstanceOf[RootNode], newGroup)
+      case IncludeNode(included, _, _) =>
+        headerRefs(included, group)
       case _ => Nil
     }
   }

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Index.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Index.scala
@@ -28,7 +28,15 @@ import scala.collection.JavaConverters._
  */
 object Index {
 
-  case class Ref(level: Int, path: String, markdown: Node, group: Option[String])
+  /**
+   * @param level
+   * @param path
+   * @param markdown
+   * @param group
+   * @param includeIndexes If this header came from an included file, this has the index of the include file,
+   *                       starting from the top level page include, down to the deepest nesting.
+   */
+  case class Ref(level: Int, path: String, markdown: Node, group: Option[String], includeIndexes: List[Int])
 
   case class Page(file: File, path: String, markdown: RootNode, properties: Map[String, String], indices: Forest[Ref], headers: Forest[Ref])
 
@@ -46,27 +54,27 @@ object Index {
    * Create a tree of header refs from a parsed markdown page.
    */
   def headers(root: RootNode): Forest[Ref] = {
-    Tree.hierarchy(headerRefs(root, group = None))(Ordering[Int].on[Ref](_.level))
+    Tree.hierarchy(headerRefs(root, group = None, includeIndexes = Nil))(Ordering[Int].on[Ref](_.level))
   }
 
   /**
    * Extract refs from markdown headers.
    */
-  private def headerRefs(root: RootNode, group: Option[String]): List[Ref] = {
+  private def headerRefs(root: RootNode, group: Option[String], includeIndexes: List[Int]): List[Ref] = {
     root.getChildren.asScala.toList.flatMap {
       case header: HeaderNode =>
         header.getChildren.asScala.toList.flatMap {
-          case anchor: AnchorLinkSuperNode => List(Ref(header.getLevel, "#" + anchor.name, anchor.contents, group))
-          case anchor: AnchorLinkNode      => List(Ref(header.getLevel, "#" + anchor.getName, new TextNode(anchor.getText), group))
+          case anchor: AnchorLinkSuperNode => List(Ref(header.getLevel, "#" + anchor.name, anchor.contents, group, includeIndexes))
+          case anchor: AnchorLinkNode      => List(Ref(header.getLevel, "#" + anchor.getName, new TextNode(anchor.getText), group, includeIndexes))
           case _                           => Nil
         }
       case node: DirectiveNode if node.format == DirectiveNode.Format.ContainerBlock =>
         // TODO check whether my assumption that Container DirectiveNode's always contain RootNode's holds,
         // if so maybe move that cast to DirectiveNode
         val newGroup = node.attributes.classes().asScala.find(_.startsWith("group-")).map(_.substring("group-".size))
-        headerRefs(node.contentsNode.asInstanceOf[RootNode], newGroup)
-      case IncludeNode(included, _, _) =>
-        headerRefs(included, group)
+        headerRefs(node.contentsNode.asInstanceOf[RootNode], newGroup, includeIndexes)
+      case node @ IncludeNode(included, _, _) =>
+        headerRefs(included, group, includeIndexes :+ node.getStartIndex)
       case _ => Nil
     }
   }
@@ -111,7 +119,7 @@ object Index {
   @tailrec
   private def linkRef(node: Node, level: Int): Option[Ref] = {
     node match {
-      case link: ExpLinkNode => Some(Ref(level, link.url, link.getChildren.get(0), group = None))
+      case link: ExpLinkNode => Some(Ref(level, link.url, link.getChildren.get(0), group = None, Nil))
       case other => other.getChildren.asScala.toList match {
         // only check first children
         case first :: _ => linkRef(first, level)

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
@@ -36,7 +36,7 @@ sealed abstract class Linkable {
 /**
  * Header in a page, with anchor path and markdown nodes.
  */
-case class Header(path: String, label: Node, group: Option[String]) extends Linkable
+case class Header(path: String, label: Node, group: Option[String], includeIndexes: List[Int]) extends Linkable
 
 /**
  * Markdown page with target path, parsed markdown, and headers.
@@ -94,10 +94,10 @@ object Page {
     val targetPath = properties.convertToTarget(convertPath)(page.path)
     val rootSrcPage = Path.relativeRootPath(page.file, page.path)
     val (h1, subheaders) = page.headers match {
-      case h :: hs => (Header(h.label.path, h.label.markdown, h.label.group), h.children ++ hs)
-      case Nil     => (Header(targetPath, new SpecialTextNode(targetPath), None), Nil)
+      case h :: hs => (Header(h.label.path, h.label.markdown, h.label.group, h.label.includeIndexes), h.children ++ hs)
+      case Nil     => (Header(targetPath, new SpecialTextNode(targetPath), None, Nil), Nil)
     }
-    val headers = subheaders map (_ map (h => Header(h.path, h.markdown, h.group)))
+    val headers = subheaders map (_ map (h => Header(h.path, h.markdown, h.group, h.includeIndexes)))
     Page(page.file, targetPath, rootSrcPage, h1.label, h1, headers, page.markdown, h1.group, properties)
   }
 
@@ -149,8 +149,8 @@ object Page {
    */
   def included(file: File, includeFilePath: String, includedIn: Page, markdown: RootNode): Page = {
     val rootSrcPage = Path.relativeRootPath(file, includeFilePath)
-    val h1 = Header(includedIn.path, new SpecialTextNode(includedIn.path), None)
-    Page(file, includedIn.path, rootSrcPage, h1.label, h1, Nil, markdown, h1.group, includedIn.properties)
+    Page(file, includedIn.path, rootSrcPage, includedIn.h1.label, includedIn.h1, includedIn.headers, markdown,
+      includedIn.group, includedIn.properties)
   }
 }
 

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
@@ -117,7 +117,8 @@ object Writer {
   def defaultPlugins(directives: Seq[Context => Directive]): Seq[Context => ToHtmlSerializerPlugin] = Seq(
     context => new ClassyLinkSerializer,
     context => new AnchorLinkSerializer,
-    context => new DirectiveSerializer(directives.map(d => d(context)))
+    context => new DirectiveSerializer(directives.map(d => d(context))),
+    context => new IncludeNodeSerializer(context)
   )
 
   def defaultDirectives: Seq[Context => Directive] = Seq(
@@ -137,7 +138,7 @@ object Writer {
     context => InlineWrapDirective("span"),
     context => InlineGroupDirective(context.groups.values.flatten.map(_.toLowerCase).toSeq),
     context => DependencyDirective(context.properties),
-    context => IncludeDirective(context)
+    context => IncludeDirective(context.location.tree.label, context.properties)
   )
 
   class DefaultLinkRenderer(context: Context) extends LinkRenderer {

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
@@ -94,15 +94,17 @@ object Writer {
    * Write context which is passed through to directives.
    */
   case class Context(
-      location:     Location[Page],
-      paths:        Set[String],
-      reader:       Reader,
-      writer:       Writer,
-      pageMappings: String => String         = Path.replaceExtension(DefaultSourceSuffix, DefaultTargetSuffix),
-      sourceSuffix: String                   = DefaultSourceSuffix,
-      targetSuffix: String                   = DefaultTargetSuffix,
-      groups:       Map[String, Seq[String]] = Map.empty,
-      properties:   Map[String, String]      = Map.empty)
+      location:       Location[Page],
+      paths:          Set[String],
+      reader:         Reader,
+      writer:         Writer,
+      pageMappings:   String => String         = Path.replaceExtension(DefaultSourceSuffix, DefaultTargetSuffix),
+      sourceSuffix:   String                   = DefaultSourceSuffix,
+      targetSuffix:   String                   = DefaultTargetSuffix,
+      groups:         Map[String, Seq[String]] = Map.empty,
+      properties:     Map[String, String]      = Map.empty,
+      includeIndexes: List[Int]                = Nil
+  )
 
   def defaultLinks(context: Context): LinkRenderer =
     new DefaultLinkRenderer(context)
@@ -129,7 +131,7 @@ object Writer {
     context => GitHubDirective(context.location.tree.label, context.properties),
     context => SnipDirective(context.location.tree.label, context.properties),
     context => FiddleDirective(context.location.tree.label, context.properties),
-    context => TocDirective(context.location),
+    context => TocDirective(context.location, context.includeIndexes),
     context => VarDirective(context.properties),
     context => VarsDirective(context.properties),
     context => CalloutDirective("note", "Note"),

--- a/tests/src/test/resources/example.conf
+++ b/tests/src/test/resources/example.conf
@@ -1,0 +1,17 @@
+# Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+//#example
+a = b
+//#example

--- a/tests/src/test/resources/headers.md
+++ b/tests/src/test/resources/headers.md
@@ -1,0 +1,2 @@
+## Heading 1
+## Heading 2

--- a/tests/src/test/resources/include-code-snip.md
+++ b/tests/src/test/resources/include-code-snip.md
@@ -1,0 +1,1 @@
+@@snip[example.conf](example.conf) { #example }

--- a/tests/src/test/resources/toc.md
+++ b/tests/src/test/resources/toc.md
@@ -1,0 +1,9 @@
+
+## This shouldn't be included since it's not below the toc
+
+More text here to ensure that the headers in the outer file which are below this pages
+inclusion but with a higher start index do still get included.
+
+Blah blah blah blah blah blah blah.
+
+@@toc { depth=1 }

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/IncludeDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/IncludeDirectiveSpec.scala
@@ -61,16 +61,46 @@ class IncludeDirectiveSpec extends MarkdownBaseSpec {
   it should "include headers from nested snippets in the toc" in {
     markdown(
       """
-        |@@toc { depth=2 }
+        |# Page heading
         |
-        |# Hello
+        |This text appears here to push down the toc so to ensure that the headers below
+        |calculation works.
+        |
+        |@@toc { depth=1 }
         |
         |@@include(tests/src/test/resources/headers.md)
+        |
+        |## Heading 3
+        |
         |""") should include(html("""
            |<div class="toc">
            |  <ul>
            |    <li><a href="test.html#heading-1" class="header">Heading 1</a></li>
            |    <li><a href="test.html#heading-2" class="header">Heading 2</a></li>
+           |    <li><a href="test.html#heading-3" class="header">Heading 3</a></li>
+           |  </ul>
+           |</div>"""))
+  }
+
+  it should "include headers from outer snippets in a nested toc" in {
+    markdown(
+      """
+        |# Page heading
+        |
+        |## Above toc
+        |
+        |@@include(tests/src/test/resources/toc.md)
+        |
+        |## Heading 1
+        |## Heading 2
+        |## Heading 3
+        |
+        |""") should include(html("""
+           |<div class="toc">
+           |  <ul>
+           |    <li><a href="test.html#heading-1" class="header">Heading 1</a></li>
+           |    <li><a href="test.html#heading-2" class="header">Heading 2</a></li>
+           |    <li><a href="test.html#heading-3" class="header">Heading 3</a></li>
            |  </ul>
            |</div>"""))
   }

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/IncludeDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/IncludeDirectiveSpec.scala
@@ -50,4 +50,29 @@ class IncludeDirectiveSpec extends MarkdownBaseSpec {
       |<p>This file should be included by IncludeDirectiveSpec</p>""")
   }
 
+  it should "include nested code snippets" in {
+    markdown("""@@include(tests/src/test/resources/include-code-snip.md)""") shouldEqual html("""
+      |<pre class="prettyprint">
+      |<code class="language-conf">
+      |a = b</code>
+      |</pre>""")
+  }
+
+  it should "include headers from nested snippets in the toc" in {
+    markdown(
+      """
+        |@@toc { depth=2 }
+        |
+        |# Hello
+        |
+        |@@include(tests/src/test/resources/headers.md)
+        |""") should include(html("""
+           |<div class="toc">
+           |  <ul>
+           |    <li><a href="test.html#heading-1" class="header">Heading 1</a></li>
+           |    <li><a href="test.html#heading-2" class="header">Heading 2</a></li>
+           |  </ul>
+           |</div>"""))
+  }
+
 }

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/SnipDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/SnipDirectiveSpec.scala
@@ -153,4 +153,25 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
         |}</code>
         |</pre>""")
   }
+
+  it should "filter labels by default" in {
+    markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #example-with-label }""") shouldEqual html(
+      """<pre class="prettyprint">
+        |<code class="language-scala">
+        |object Constants {
+        |}</code>
+        |</pre>"""
+    )
+  }
+
+  it should "allow including labels if specified" in {
+    markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #example-with-label filterLabels=false }""") shouldEqual html(
+      """<pre class="prettyprint">
+        |<code class="language-scala">
+        |object Constants {
+        |  val someString = " #foo "
+        |}</code>
+        |</pre>"""
+    )
+  }
 }

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/SnippetIndentationTest.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/SnippetIndentationTest.scala
@@ -151,6 +151,6 @@ class SnippetIndentationTest extends FlatSpec with Matchers {
 
   def extractToString(inString: String, label: String, indentationPerSnippet: Boolean = true): String = {
     val in = inString.split("\n").toList
-    Snippet.extract(new File(""), in, Seq(label))
+    Snippet.extract(new File(""), in, Seq(label), true)
   }
 }

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala
@@ -73,3 +73,10 @@ class AnotherClass
 
   //#multi-indented-example
 // format: ON
+
+
+//#example-with-label
+object Constants {
+  val someString = " #foo "
+}
+//#example-with-label


### PR DESCRIPTION
This improves the includes, so rather than the included markdown being parsed at the parent parents render time, it's parsed and then included in the AST straight after the parent page is parsed.

One consequence of this is that now the right hand page navigation works, since the headers can be extracted from the included markdown. I think it's also more robust all around.

In order to implement this, I had to create a new node, an `IncludeNode`, which doesn't get parsed (the include is still a `DirectiveNode`), but rather a post parse processing step converts the include `DirectiveNode`'s into `IncludeNode`'s, by parsing the included file. The `IncludeNode` then has the included files `RootNode` in it, along with the included path and file object. Then, a serializer plugin, when it encounters the `IncludeNode`, creates a new context based on the file that the node came from, and renders the nodes children into that - this ensures that included files can still have things like snips with paths relative to the included file.

Doing all this exposed an issue - since we expect included markdown files to include directives that may contain things that look like labels, it would have a problem with #149. So I made the snippet parser be able to turn on or off the filtering out of lines containing labels. The include directive turns this off by default, while the snip and other directives turn it on by default. Since that option now existed, I also added support to all of the above directives to configure it, via a `filterLabel` flag. This provides a work around, if not a fix, to #149.