### PR TITLE
Add project info plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ inThisBuild(List(
   crossScalaVersions := Seq("2.10.7", "2.12.7"),
   organizationName := "lightbend",
   organizationHomepage := Some(url("https://lightbend.com/")),
-  homepage := Some(url("https://github.com/lightbend/paradox")),
+  homepage := Some(url("https://developer.lightbend.com/docs/paradox/current/")),
   scmInfo := Some(ScmInfo(url("https://github.com/lightbend/paradox"), "git@github.com:lightbend/paradox.git")),
   developers := List(
     Developer("pvlugter", "Peter Vlugter", "@pvlugter", url("https://github.com/pvlugter")),

--- a/core/src/main/java/org/pegdown/ParserWithDirectives.java
+++ b/core/src/main/java/org/pegdown/ParserWithDirectives.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/pegdown/ast/AnchorLinkSuperNode.java
+++ b/core/src/main/java/org/pegdown/ast/AnchorLinkSuperNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/pegdown/ast/ClassyLinkNode.java
+++ b/core/src/main/java/org/pegdown/ast/ClassyLinkNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/pegdown/ast/DirectiveAttributes.java
+++ b/core/src/main/java/org/pegdown/ast/DirectiveAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/pegdown/ast/DirectiveNode.java
+++ b/core/src/main/java/org/pegdown/ast/DirectiveNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/pegdown/ast/VerbatimGroupNode.java
+++ b/core/src/main/java/org/pegdown/ast/VerbatimGroupNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
+++ b/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/AnchorLink.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/AnchorLink.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Breadcrumbs.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Breadcrumbs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/ClassyLink.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/ClassyLink.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Frontin.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Frontin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Groups.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Groups.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/IncludeNode.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/IncludeNode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Index.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Index.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Reader.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Reader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Snippet.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Snippet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/StyledVerbatim.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/StyledVerbatim.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/TableOfContents.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/TableOfContents.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Url.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Url.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/template/PageTemplate.scala
+++ b/core/src/main/scala/com/lightbend/paradox/template/PageTemplate.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/lightbend/paradox/tree/Tree.scala
+++ b/core/src/main/scala/com/lightbend/paradox/tree/Tree.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/main/paradox/overview.md
+++ b/docs/src/main/paradox/overview.md
@@ -16,13 +16,13 @@ It has several features that help to structure and build documentation sites eas
    @ref[Themes](customization/theming.md) allow customizing the appearance of Paradox-generated documentation. Custom 
    directives and themes can be packaged and published as separate sbt plugin @ref[extensions](customization/extensions.md).
 
-### Source Code
+### Project info
 
-The GitHub repository can be found at [lightbend/paradox][repo].
- 
+@@project-info{ projectId="core" }
+
 ### License and credits
  
- - Copyright 2015-2018 Lightbend, Inc. Paradox is provided under the Apache 2.0 license.
+ - Copyright 2015-2019 Lightbend, Inc. Paradox is provided under the Apache 2.0 license.
  - **Paradox is NOT supported under the Lightbend subscription.**
  - The markdown engine is based on Mathias's [Pegdown][]. 
  

--- a/docs/src/main/resources/tab-switching/examples.java
+++ b/docs/src/main/resources/tab-switching/examples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/main/resources/tab-switching/examples.scala
+++ b/docs/src/main/resources/tab-switching/examples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/main/scala/Hello.scala
+++ b/docs/src/main/scala/Hello.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/scala-sbt-1.0/com/lightbend/paradox/sbt/Compat.scala
+++ b/plugin/src/main/scala-sbt-1.0/com/lightbend/paradox/sbt/Compat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxKeys.scala
+++ b/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxKeys.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
+++ b/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -68,7 +68,7 @@ object Common extends AutoPlugin {
   )
 
   val licenseText: String = {
-    """|Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+    """|Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
 
        |Licensed under the Apache License, Version 2.0 (the "License");
        |you may not use this file except in compliance with the License.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,6 +17,7 @@
 addSbtPlugin("org.scalariform"       % "sbt-scalariform" % "1.8.2")
 addSbtPlugin("de.heikoseeberger"     % "sbt-header"      % "5.1.0")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox"     % "0.5.0")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "1.1.1")
 addSbtPlugin("com.geirsson"          % "sbt-ci-release"  % "1.2.1")
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -1,0 +1,29 @@
+project-info {
+  version: "current"
+  shared-info {
+    jdk-versions: ["Oracle JDK 8", "Open JDK 11"]
+    issues: {
+      url: "https://github.com/lightbend/paradox/issues"
+      text: "Github issues"
+    }
+    release-notes: {
+      url: "https://github.com/lightbend/paradox/releases"
+      text: "Github releases"
+    }
+    forums: [
+    ]
+  }
+  core: ${project-info.shared-info} {
+    title: "Paradox"
+    levels: [
+      {
+        readiness: CommunityDriven
+        since: "2015-08-03"
+        since-version: "0.1.0"
+        note: "Paradox is used by Lightbend to create documentation sites. Use at your own convenience."
+      }
+    ]
+    api-docs: [
+    ]
+  }
+}

--- a/testkit/src/main/scala/com/lightbend/paradox/markdown/MarkdownTestkit.scala
+++ b/testkit/src/main/scala/com/lightbend/paradox/markdown/MarkdownTestkit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/resources/example.conf
+++ b/tests/src/test/resources/example.conf
@@ -1,4 +1,4 @@
-# Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+# Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/AnchorLinkSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/AnchorLinkSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/CalloutDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/CalloutDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/DependencyDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/DependencyDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/ExtRefDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/ExtRefDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/FiddleDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/FiddleDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/FrontinSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/FrontinSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/GitHubDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/GitHubDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/IncludeDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/IncludeDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/IndexSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/IndexSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/InlineGroupDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/InlineGroupDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/InlineWrapDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/InlineWrapDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/JavadocDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/JavadocDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/LayoutSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/LayoutSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/MarkdownBaseSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/MarkdownBaseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/NavigationSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/NavigationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/PagePropertiesSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/PagePropertiesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/PathSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/PathSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/PropertiesLoadSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/PropertiesLoadSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/RefDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/RefDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/ScaladocDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/ScaladocDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/SnipDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/SnipDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/SnippetIndentationTest.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/SnippetIndentationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/TocDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/TocDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/VarDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/VarDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/VarsDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/VarsDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/WrapDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/WrapDirectiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/example2.java
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/example2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/theme-plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxThemePlugin.scala
+++ b/theme-plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxThemePlugin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 - 2017 Lightbend, Inc. <http://www.lightbend.com>
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Makes the site generate project info as this

![bild](https://user-images.githubusercontent.com/458526/53973822-c0fba200-4101-11e9-8bc7-048a0f4058fa.png)

And changes copyright notice to 2019 in the other commit.