### PR TITLE
Fixed property name to canonical.base_url

### DIFF
--- a/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
+++ b/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
@@ -97,7 +97,7 @@ object ParadoxPlugin extends AutoPlugin {
       homepage.value match {
         case Some(url) => Map(
           "project.url" -> url.toString,
-          "canonical.base_dir" -> url.toString
+          "canonical.base_url" -> url.toString
         )
         case None => Map.empty
       }


### PR DESCRIPTION
I mixed up names and use the wrong name when auto-defining the property from the `homepage` setting.