### PR TITLE
Separate html and theme output per configuration

### DIFF
--- a/docs/src/main/paradox/configuration.md
+++ b/docs/src/main/paradox/configuration.md
@@ -32,7 +32,7 @@ If a file duplicate exist between the directories, the overlay file is dropped i
 By default, Paradox expects documentation source files in the `src/main/paradox` directory.
 For situations where different parts of the documentation are stored separately, Paradox supports custom sbt configuration scopes.
 Each custom configuration source files are by default located in the `src/<config-name>/paradox` directory.
-Target directory is defined as `target/paradox/site/<config-name>`.
+The target directory is defined as `target/paradox/site/<config-name>`.
 Here `<config-name>` corresponds to `configuration.name` of a particular configuration.
 
 To associate a configuration to paradox, manually add settings from `ParadoxPlugin.paradoxSettings`, and change its default source and/or target directories if needed:

--- a/docs/src/main/paradox/configuration.md
+++ b/docs/src/main/paradox/configuration.md
@@ -29,7 +29,7 @@ If a file duplicate exist between the directories, the overlay file is dropped i
 
 ## Multi Configuration
 
-By default, Paradox expects documentation source files in the `src/main/pardox` directory.
+By default, Paradox expects documentation source files in the `src/main/paradox` directory.
 For situations where different parts of the documentation are stored separately, Paradox supports custom sbt configuration scopes.
 Each custom configuration source files are by default located in the `src/<config-name>/paradox` directory.
 Target directory is defined as `target/paradox/site/<config-name>`.

--- a/docs/src/main/paradox/configuration.md
+++ b/docs/src/main/paradox/configuration.md
@@ -29,12 +29,13 @@ If a file duplicate exist between the directories, the overlay file is dropped i
 
 ## Multi Configuration
 
-Paradox supports multiple sbt configurations. Each configuration is by default located to `src/configName` of the project,
-with the target directory defined as `target/paradox/site/configName`, `configName` corresponding to configuration.name of
-a particular configuration. There still remains the usual main project in `src/main` of course if you don't need multiple
-paradox project directories.
+By default, Paradox expects documentation source files in the `src/main/pardox` directory.
+For situations where different parts of the documentation are stored separately, Paradox supports custom sbt configuration scopes.
+Each custom configuration source files are by default located in the `src/<config-name>/paradox` directory.
+Target directory is defined as `target/paradox/site/<config-name>`.
+Here `<config-name>` corresponds to `configuration.name` of a particular configuration.
 
-To associate a configuration to paradox, use its settings, and change its default source and/or target directorie(s) if needed:
+To associate a configuration to paradox, manually add settings from `ParadoxPlugin.paradoxSettings`, and change its default source and/or target directories if needed:
 
 ```scala
 val SomeConfig = config("some-config")
@@ -49,7 +50,8 @@ lazy val root = (project in file(".")).
   )
 ```
 
-Now, either you run paradox on one configuration; "sbt someConfig:paradox" or you can run the main project with the usual way; "sbt paradox".
+Now, to run paradox for custom configuration execute `sbt someConfig:paradox`.
+It is still possible to run paradox for the main configuration the usual way `sbt paradox`.
 
 ## Version warning
 

--- a/plugin/src/sbt-test/paradox/custom-configuration/build.sbt
+++ b/plugin/src/sbt-test/paradox/custom-configuration/build.sbt
@@ -1,0 +1,23 @@
+val Docs1 = config("docs1")
+val Docs2 = config("docs2")
+
+enablePlugins(ParadoxPlugin)
+
+ParadoxPlugin.paradoxSettings(Docs1)
+ParadoxPlugin.paradoxSettings(Docs2)
+
+TaskKey[Unit]("makeDocs") := {
+  (Docs1 / paradox).value
+  (Docs2 / paradox).value
+}
+
+TaskKey[Unit]("check") := {
+  def checkFileContent(file: File, expected: String) = {
+    assert(file.exists, s"${file.getAbsolutePath} does not exists")
+    val contents = IO.readLines(file)
+    assert(contents.exists(_.contains(expected)), s"Did not find '$expected' in\n${contents.mkString("\n")}")
+  }
+
+  checkFileContent((Docs1 / paradox / target).value / "index.html", "Docs1 index")
+  checkFileContent((Docs2 / paradox / target).value / "index.html", "Docs2 index")
+}

--- a/plugin/src/sbt-test/paradox/custom-configuration/project/build.properties
+++ b/plugin/src/sbt-test/paradox/custom-configuration/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.8

--- a/plugin/src/sbt-test/paradox/custom-configuration/project/plugins.sbt
+++ b/plugin/src/sbt-test/paradox/custom-configuration/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % sys.props("project.version"))

--- a/plugin/src/sbt-test/paradox/custom-configuration/src/docs1/paradox/index.md
+++ b/plugin/src/sbt-test/paradox/custom-configuration/src/docs1/paradox/index.md
@@ -1,0 +1,1 @@
+Docs1 index.

--- a/plugin/src/sbt-test/paradox/custom-configuration/src/docs2/paradox/index.md
+++ b/plugin/src/sbt-test/paradox/custom-configuration/src/docs2/paradox/index.md
@@ -1,0 +1,1 @@
+Docs2 index.

--- a/plugin/src/sbt-test/paradox/custom-configuration/test
+++ b/plugin/src/sbt-test/paradox/custom-configuration/test
@@ -1,0 +1,2 @@
+> makeDocs
+> check


### PR DESCRIPTION
Without the separation, the results of the parsed markdown files and themes are reused across configurations.