### PR TITLE
Allow `@ref` in index; introduce `@link`

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -166,7 +166,7 @@ case class LinkDirective(page: Page, pathExists: String => Boolean, convertPath:
   extends InlineDirective("link", "link:") with SourceDirective {
 
   def render(node: DirectiveNode, visitor: Visitor, printer: Printer): Unit =
-    new ExpLinkNode(node.label, resolvedSource(node, page), node.contentsNode).accept(visitor)
+    new ExpLinkNodeExtended(node.label, resolvedSource(node, page), node.contentsNode, node.attributes).accept(visitor)
 
 }
 

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -156,6 +156,10 @@ object RefDirective {
    */
   class LinkException(message: String) extends RuntimeException(message)
 
+  def isRefDirective(node: DirectiveNode): Boolean = {
+    node.format == DirectiveNode.Format.Inline && (node.name == "ref" || node.name == "ref:")
+  }
+
 }
 
 /**

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -162,6 +162,20 @@ object RefDirective {
 
 }
 
+case class LinkDirective(page: Page, pathExists: String => Boolean, convertPath: String => String, variables: Map[String, String])
+  extends InlineDirective("link", "link:") with SourceDirective {
+
+  def render(node: DirectiveNode, visitor: Visitor, printer: Printer): Unit =
+    new ExpLinkNode(node.label, resolvedSource(node, page), node.contentsNode).accept(visitor)
+
+}
+
+object LinkDirective {
+  def isLinkDirective(node: DirectiveNode): Boolean = {
+    node.format == DirectiveNode.Format.Inline && (node.name == "link" || node.name == "link:")
+  }
+}
+
 /**
  * Link to external sites using URI templates.
  */

--- a/core/src/main/scala/com/lightbend/paradox/markdown/ExpLinkNodeExtended.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/ExpLinkNodeExtended.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.paradox.markdown
+
+import org.pegdown.ast.{ DirectiveAttributes, ExpLinkNode, Node }
+
+class ExpLinkNodeExtended(url: String, title: String, child: Node, val attributes: DirectiveAttributes) extends ExpLinkNode(url, title, child)

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
@@ -125,6 +125,7 @@ object Writer {
 
   def defaultDirectives: Seq[Context => Directive] = Seq(
     context => RefDirective(context.location.tree.label, context.paths, context.pageMappings, context.properties),
+    context => LinkDirective(context.location.tree.label, context.paths, context.pageMappings, context.properties),
     context => ExtRefDirective(context.location.tree.label, context.properties),
     context => ScaladocDirective(context.location.tree.label, context.properties),
     context => JavadocDirective(context.location.tree.label, context.properties),

--- a/docs/src/main/paradox/directives/directives-alphabetically.md
+++ b/docs/src/main/paradox/directives/directives-alphabetically.md
@@ -7,6 +7,7 @@
  * @ref[`@@include`](includes.md)
  * @ref[`@@@index`](organizing-pages.md#index-container)
  * @ref[`@javadoc`](linking.md#javadoc)
+ * @ref[`@link`](linking.md#ref-link)
  * @ref[`@@@note`](callouts.md#note-callout)
  * @ref[`@ref`](linking.md#ref-link)
  * @ref[`@scaladoc`](linking.md#scaladoc)

--- a/docs/src/main/paradox/directives/linking.md
+++ b/docs/src/main/paradox/directives/linking.md
@@ -1,6 +1,14 @@
 Linking
 -------
 
+#### External links
+
+External links can be created with the default markdown syntax `[text](url)`. Additionally Paradox introduces `@link:` with the same features.
+
+```
+See the @link:[Paradox GitHub repo](https://github.com/lightbend/paradox) for more information.
+```
+
 #### @ref link
 
 Paradox extensions are designed so the resulting Markdown is Github friendly.

--- a/docs/src/main/paradox/directives/linking.md
+++ b/docs/src/main/paradox/directives/linking.md
@@ -3,10 +3,10 @@ Linking
 
 #### External links
 
-External links can be created with the default markdown syntax `[text](url)`. Additionally Paradox introduces `@link:` with the same features.
+External links can be created with the default markdown syntax `[text](url)`. Additionally Paradox introduces `@link:` which accepts the `open=new` attribute to make the link open in a new browser tab (it adds `target="_blank" rel="noopener noreferrer"` to the anchor tag).
 
 ```
-See the @link:[Paradox GitHub repo](https://github.com/lightbend/paradox) for more information.
+See the @link:[Paradox GitHub repo](https://github.com/lightbend/paradox) { open=new } for more information.
 ```
 
 #### @ref link

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/IndexSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/IndexSpec.scala
@@ -46,6 +46,68 @@ class IndexSpec extends MarkdownBaseSpec {
       """)
   }
 
+  it should "create toc" in {
+    indexed(
+      "a.md" -> """
+        |# A
+        |@@@ index
+        |* @ref:[Big B](b.md)
+        |@@@
+        |
+        |@ref:[b](b.md)
+      """,
+      "b.md" -> """
+        |# B
+        |## B2
+      """) shouldEqual index(
+        """
+        |- a.html
+        |  - b.html
+        |    - #b2
+      """)
+  }
+
+  it should "create page tree with refs" in {
+    indexed(
+      "a.md" -> """
+                  |# A
+                  |@@@ index
+                  |* @ref:[b](b.md)
+                  |* @ref:[c](c.md)
+                  |@@@
+                  |## A2
+                  |### A3
+                """,
+      "b.md" -> """
+                  |# B
+                  |@@@ index
+                  |* @ref[d](d.md)
+                  |@@@
+                  |## B2
+                """,
+      "c.md" -> """
+                  |# C
+                  |## C2
+                """,
+      "d.md" -> """
+                  |# D
+                  |## D2
+                  |### D3
+                """) shouldEqual index(
+        """
+        |- a.html
+        |  - #a2
+        |    - #a3
+        |  - b.html
+        |    - #b2
+        |    - d.html
+        |      - #d2
+        |        - #d3
+        |  - c.html
+        |    - #c2
+      """)
+  }
+
   it should "create page tree" in {
     indexed(
       "a.md" -> """

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/IndexSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/IndexSpec.scala
@@ -53,8 +53,6 @@ class IndexSpec extends MarkdownBaseSpec {
         |@@@ index
         |* @ref:[Big B](b.md)
         |@@@
-        |
-        |@ref:[b](b.md)
       """,
       "b.md" -> """
         |# B

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/LinkDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/LinkDirectiveSpec.scala
@@ -45,9 +45,9 @@ class LinkDirectiveSpec extends MarkdownBaseSpec {
       testHtml("""<p>This <a href="external.pdf" title="Page">Page</a> is linked.</p>""")
   }
 
-  it should "parse but ignore directive attributes" in {
-    testMarkdown("This @link:[Page](page.pdf) { .ref a=1 } is linked.") shouldEqual
-      testHtml("""<p>This <a href="page.pdf" title="Page">Page</a> is linked.</p>""")
+  it should "use the `open` attributes" in {
+    testMarkdown("This @link:[Page](page.pdf) { open=new } is linked.") shouldEqual
+      testHtml("""<p>This <a href="page.pdf" title="Page" target="_blank" rel="noopener noreferrer">Page</a> is linked.</p>""")
   }
 
   it should "support referenced links with implicit key" in {

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/LinkDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/LinkDirectiveSpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.paradox.markdown
+
+class LinkDirectiveSpec extends MarkdownBaseSpec {
+
+  private implicit val context = writerContextWithProperties("page.variable" -> "https://page")
+
+  def testMarkdown(text: String, pagePath: String = "page.md", testPath: String = "test.md"): Map[String, String] = markdownPages(
+    testPath -> text
+  )
+
+  def testHtml(text: String, pagePath: String = "page.html", testPath: String = "test.html"): Map[String, String] = {
+    htmlPages(testPath -> text)
+  }
+
+  "Link directive" should "create links" in {
+    testMarkdown("@link[External page](https://domain.com/page.html)") shouldEqual testHtml("""<p><a href="https://domain.com/page.html" title="External page">External page</a></p>""")
+  }
+
+  it should "support 'link:' as an alternative name" in {
+    testMarkdown("@link:[External page](https://domain.com/page.html)") shouldEqual testHtml("""<p><a href="https://domain.com/page.html" title="External page">External page</a></p>""")
+  }
+
+  it should "handle anchored links correctly" in {
+    testMarkdown("@link:[External page](https://domain.com/page.html#anchor)") shouldEqual testHtml("""<p><a href="https://domain.com/page.html#anchor" title="External page">External page</a></p>""")
+  }
+
+  it should "retain whitespace before or after" in {
+    testMarkdown("This @link:[Page](external.pdf) is linked.") shouldEqual
+      testHtml("""<p>This <a href="external.pdf" title="Page">Page</a> is linked.</p>""")
+  }
+
+  it should "parse but ignore directive attributes" in {
+    testMarkdown("This @link:[Page](page.pdf) { .ref a=1 } is linked.") shouldEqual
+      testHtml("""<p>This <a href="page.pdf" title="Page">Page</a> is linked.</p>""")
+  }
+
+  it should "support referenced links with implicit key" in {
+    testMarkdown(
+      """This @link:[SBT] { .ref a=1 } is linked.
+        |
+        |  [SBT]: https://scala-sbt.org
+      """.stripMargin) shouldEqual testHtml("""<p>This <a href="https://scala-sbt.org" title="SBT">SBT</a> is linked.</p>""")
+  }
+
+  it should "support referenced links with empty key" in {
+    testMarkdown(
+      """This @link:[SBT][] is linked.
+        |
+        |  [SBT]: https://scala-sbt.org
+      """.stripMargin) shouldEqual testHtml("""<p>This <a href="https://scala-sbt.org" title="SBT">SBT</a> is linked.</p>""")
+  }
+
+  it should "support referenced links with defined key" in {
+    testMarkdown(
+      """This @link:[Page][123] { .ref a=1 } is linked.
+        |
+        |  [123]: https://scala-sbt.org
+      """.stripMargin) shouldEqual testHtml("""<p>This <a href="https://scala-sbt.org" title="Page">Page</a> is linked.</p>""")
+  }
+
+  it should "throw link exceptions for invalid reference keys" in {
+    the[RefDirective.LinkException] thrownBy {
+      markdown("@ref[Page][123]")
+    } should have message "Undefined reference key [123] in [test.html]"
+  }
+
+  it should "support variables in link paths" in {
+    testMarkdown("@link[Page]($page.variable$.html)") shouldEqual testHtml("""<p><a href="https://page.html" title="Page">Page</a></p>""")
+  }
+
+}


### PR DESCRIPTION
Changed and added directives:
* `@ref` is now allowed in `@@@index` sections, which is equivalent to usual markdown `[..](..)`
* `@link` may be used as an alternative to markdown's `[..](..)` with the additional feature to add an `open=new` attribute to make the link open in a new browser 

This is some groundwork to implement #286 which may allow using `@link` in `@@@index` sections.