### PR TITLE
Support github enterprise links

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -298,16 +298,18 @@ case class JavadocDirective(page: Page, variables: Map[String, String])
 
 object GitHubResolver {
   val baseUrl = "github.base_url"
+  val githubDomain = "github.domain"
 }
 
 trait GitHubResolver {
 
   def variables: Map[String, String]
 
+  lazy val githubDomain = variables.get(GitHubResolver.githubDomain).getOrElse("github.com")
   val IssuesLink = """([^/]+/[^/]+)?#([0-9]+)""".r
   val CommitLink = """(([^/]+/[^/]+)?@)?(\p{XDigit}{5,40})""".r
-  val TreeUrl = """(.*github.com/[^/]+/[^/]+/tree/[^/]+)""".r
-  val ProjectUrl = """(.*github.com/[^/]+/[^/]+).*""".r
+  lazy val TreeUrl = (s"(.*$githubDomain/[^/]+/[^/]+/tree/[^/]+)").r
+  lazy val ProjectUrl = (s"(.*$githubDomain/[^/]+/[^/]+).*").r
 
   val baseUrl = PropertyUrl(GitHubResolver.baseUrl, variables.get)
 
@@ -341,7 +343,7 @@ trait GitHubResolver {
 
   protected def resolveProject(project: String) = {
     Option(project) match {
-      case Some(path) => Url("https://github.com") / path
+      case Some(path) => Url(s"https://$githubDomain") / path
       case None       => projectUrl
     }
   }

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/GitHubDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/GitHubDirectiveSpec.scala
@@ -32,6 +32,15 @@ class GitHubDirectiveSpec extends MarkdownBaseSpec {
       html("""<p><a href="https://github.com/lightbend/paradox/issues/1">#1</a></p>""")
   }
 
+  it should "support github enterprise deployments" in {
+    implicit val context = writerContextWithProperties(
+      "github.base_url" -> "https://git.enterprise.net/lightbend/paradox/tree/v0.2.1",
+      "github.root.base_dir" -> ".",
+      "github.domain" -> "git.enterprise.net")
+    markdown("@github:[#1](#1)") shouldEqual
+      html("""<p><a href="https://git.enterprise.net/lightbend/paradox/issues/1">#1</a></p>""")
+  }
+
   it should "retain whitespace before or after" in {
     markdown("The @github:[#1](#1) issue") shouldEqual
       html("""<p>The <a href="https://github.com/lightbend/paradox/issues/1">#1</a> issue</p>""")


### PR DESCRIPTION
Hi,
I'm trying to use paradox at my company. Currently, we use github enterprise deployed with the domain `git.dev.<enterprise>.net`. I was wondering if this change would let us add the link to the end of code snippets? Or if there's a better way of doing this?