### PR TITLE
FilterLabels: off for unlabeled includes

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
+++ b/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
@@ -235,7 +235,7 @@ class ParadoxProcessor(reader: Reader = new Reader, writer: Writer = new Writer)
         }
         val includeFile = SourceDirective.resolveFile("include", source, file, properties)
         val frontin = Frontin(includeFile)
-        val filterLabels = include.attributes.booleanValue(
+        val filterLabels = labels.nonEmpty && include.attributes.booleanValue(
           "filterLabels",
           properties.get("include.filterLabels").exists(_ == "true"))
         val (text, snippetLang) = Snippet(includeFile, labels, filterLabels)

--- a/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
+++ b/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
@@ -235,9 +235,7 @@ class ParadoxProcessor(reader: Reader = new Reader, writer: Writer = new Writer)
         }
         val includeFile = SourceDirective.resolveFile("include", source, file, properties)
         val frontin = Frontin(includeFile)
-        val filterLabels = labels.nonEmpty && include.attributes.booleanValue(
-          "filterLabels",
-          properties.get("include.filterLabels").exists(_ == "true"))
+        val filterLabels = Directive.filterLabels("include", include.attributes, labels, properties)
         val (text, snippetLang) = Snippet(includeFile, labels, filterLabels)
         // I guess we could support multiple markup languages in future...
         if (snippetLang != "md" && snippetLang != "markdown") {

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -393,7 +393,7 @@ case class SnipDirective(page: Page, variables: Map[String, String])
     try {
       val labels = node.attributes.values("identifier").asScala
       val source = resolvedSource(node, page)
-      val filterLabels = node.attributes.booleanValue("filterLabels", variables.get("snip.filterLabels").forall(_ == "true"))
+      val filterLabels = labels.nonEmpty && node.attributes.booleanValue("filterLabels", variables.get("snip.filterLabels").forall(_ == "true"))
       val file = resolveFile("snip", source, page, variables)
       val (text, snippetLang) = Snippet(file, labels, filterLabels)
       val lang = Option(node.attributes.value("type")).getOrElse(snippetLang)
@@ -451,7 +451,7 @@ case class FiddleDirective(page: Page, variables: Map[String, String])
 
       val source = resolvedSource(node, page)
       val file = resolveFile("fiddle", source, page, variables)
-      val filterLabels = node.attributes.booleanValue("filterLabels", variables.get("fiddle.filterLabels").forall(_ == "true"))
+      val filterLabels = labels.nonEmpty && node.attributes.booleanValue("filterLabels", variables.get("fiddle.filterLabels").forall(_ == "true"))
       val (code, _) = Snippet(file, labels, filterLabels)
 
       printer.println.print(s"""

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -58,6 +58,15 @@ abstract class Directive {
   def render(node: DirectiveNode, visitor: Visitor, printer: Printer): Unit
 }
 
+object Directive {
+  def filterLabels(prefix: String, attributes: DirectiveAttributes, labels: Seq[String], properties: Map[String, String]): Boolean = attributes.value("filterLabels", "") match {
+    case "true" | "on" | "yes"  => true
+    case "false" | "off" | "no" => false
+    case ""                     => labels.nonEmpty && properties.get(s"$prefix.filterLabels").forall(_ == "true")
+  }
+
+}
+
 /**
  * Inline directive.
  */
@@ -393,7 +402,7 @@ case class SnipDirective(page: Page, variables: Map[String, String])
     try {
       val labels = node.attributes.values("identifier").asScala
       val source = resolvedSource(node, page)
-      val filterLabels = labels.nonEmpty && node.attributes.booleanValue("filterLabels", variables.get("snip.filterLabels").forall(_ == "true"))
+      val filterLabels = Directive.filterLabels("snip", node.attributes, labels, variables)
       val file = resolveFile("snip", source, page, variables)
       val (text, snippetLang) = Snippet(file, labels, filterLabels)
       val lang = Option(node.attributes.value("type")).getOrElse(snippetLang)
@@ -451,7 +460,7 @@ case class FiddleDirective(page: Page, variables: Map[String, String])
 
       val source = resolvedSource(node, page)
       val file = resolveFile("fiddle", source, page, variables)
-      val filterLabels = labels.nonEmpty && node.attributes.booleanValue("filterLabels", variables.get("fiddle.filterLabels").forall(_ == "true"))
+      val filterLabels = Directive.filterLabels("fiddle", node.attributes, labels, variables)
       val (code, _) = Snippet(file, labels, filterLabels)
 
       printer.println.print(s"""

--- a/docs/src/main/paradox/directives/snippets.md
+++ b/docs/src/main/paradox/directives/snippets.md
@@ -54,14 +54,14 @@ Gradle
 #### Label filtering
 
 Any lines containing `#labels` within the included snippet are filtered out. This filtering can
-be switched off with `filterLabels`. It is not applied for snippets that include the whole file
-(without limiting the snippet by providing a label).
+be switched off with `filterLabels`. It is off by default for snippets that include the whole file
+(without limiting the snippet by providing a label) and can be set to `true` to overwrite that.
 
 ```markdown
 @@snip [example.log](example.log) { #example-log filterLabels=false }
 ```
 
-Or globally with the `include.filterLabels` property.
+The default value is set with the `include.filterLabels` property.
 
 ```
 paradoxProperties += "snip.filterLabels" -> "false"

--- a/docs/src/main/paradox/directives/snippets.md
+++ b/docs/src/main/paradox/directives/snippets.md
@@ -50,6 +50,33 @@ Maven
 Gradle
 :   @@snip [build.gradle](/docs/src/main/resources/build.gradle) { #setup_example }
 
+
+#### Label filtering
+
+Any lines containing `#labels` within the included snippet are filtered out. This filtering can
+be switched off with `filterLabels`. It is not applied for snippets that include the whole file
+(without limiting the snippet by providing a label).
+
+```markdown
+@@snip [example.log](example.log) { #example-log filterLabels=false }
+```
+
+Or globally with the `include.filterLabels` property.
+
+```
+paradoxProperties += "snip.filterLabels" -> "false"
+```
+
+This label filtering applies to @ref:[Markdown includes](includes.md) and @ref:[Fiddle includes](fiddles.md), as well.
+
+```
+paradoxProperties += "include.filterLabels" -> "false",
+paradoxProperties += "fiddle.filterLabels" -> "false"
+```
+
+
+#### Syntax highlighting
+
 By default, Paradox uses Prettify to highlight code and will try to detect the
 language of the snippet using the file extension. In cases where a snippet
 should not be highlighted set `type=text` in the directive's attribute section:

--- a/plugin/src/sbt-test/paradox/snippet-noindent-writer/src/main/paradox/code-samples/Hello.scala
+++ b/plugin/src/sbt-test/paradox/snippet-noindent-writer/src/main/paradox/code-samples/Hello.scala
@@ -1,4 +1,3 @@
-// #hello_example
 object Hello extends App {
   def say(str: String): Unit = {
     println(str)
@@ -6,4 +5,3 @@ object Hello extends App {
   
   say("hello")
 }
-// #hello_example

--- a/plugin/src/sbt-test/paradox/snippets/expected/reference.html
+++ b/plugin/src/sbt-test/paradox/snippets/expected/reference.html
@@ -1,9 +1,13 @@
 <pre class="prettyprint"><code class="language-conf"># This should be included
 #and this as well
+#and-this-line-should-be-skipped-when-using-labels
 
 snippets {
+  #snip
   # this snip is a snap
+  #and-this-line-should-be-skipped-when-using-labels
   snip = &quot;snap&quot;
+  #snip
 }</code></pre>
 <pre class="prettyprint"><code class="language-conf"># this snip is a snap
 snip = &quot;snap&quot;</code></pre>

--- a/plugin/src/sbt-test/paradox/snippets/expected/reference.html
+++ b/plugin/src/sbt-test/paradox/snippets/expected/reference.html
@@ -1,13 +1,10 @@
 <pre class="prettyprint"><code class="language-conf"># This should be included
 #and this as well
-#and-this-line-should-be-skipped-when-using-labels
 
 snippets {
-  #snip
   # this snip is a snap
-  #and-this-line-should-be-skipped-when-using-labels
   snip = &quot;snap&quot;
-  #snip
 }</code></pre>
+<!-- -->
 <pre class="prettyprint"><code class="language-conf"># this snip is a snap
 snip = &quot;snap&quot;</code></pre>

--- a/plugin/src/sbt-test/paradox/snippets/src/main/paradox/reference.md
+++ b/plugin/src/sbt-test/paradox/snippets/src/main/paradox/reference.md
@@ -1,3 +1,5 @@
-@@ snip [whole file](../../test/resources/reference.conf)
+@@ snip [whole file](../../test/resources/reference.conf) { filterLabels=true }
+
+<!-- -->
 
 @@ snip [snip snippet](../../test/resources/reference.conf) { #snip }

--- a/plugin/src/sbt-test/paradox/snippets/src/test/resources/reference.conf
+++ b/plugin/src/sbt-test/paradox/snippets/src/test/resources/reference.conf
@@ -1,11 +1,11 @@
 # This should be included
 #and this as well
-#and-this-line-should-be-skipped
+#and-this-line-should-be-skipped-when-using-labels
 
 snippets {
   #snip
   # this snip is a snap
-  #and-this-line-should-be-skipped
+  #and-this-line-should-be-skipped-when-using-labels
   snip = "snap"
   #snip
 }

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/SnipDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/SnipDirectiveSpec.scala
@@ -154,6 +154,96 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
         |</pre>""")
   }
 
+  it should "include labels when including the whole file" in {
+    markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala)""") shouldEqual html(
+      """<pre class="prettyprint">
+        |<code class="language-scala">
+        |/*
+        | * Copyright &copy; 2015 - 2019 Lightbend, Inc. &lt;http://www.lightbend.com&gt;
+        | *
+        | * Licensed under the Apache License, Version 2.0 (the "License");
+        | * you may not use this file except in compliance with the License.
+        | * You may obtain a copy of the License at
+        | *
+        | * http://www.apache.org/licenses/LICENSE-2.0
+        | *
+        | * Unless required by applicable law or agreed to in writing, software
+        | * distributed under the License is distributed on an "AS IS" BASIS,
+        | * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        | * See the License for the specific language governing permissions and
+        | * limitations under the License.
+        | */
+        |
+        |package com.lightbend.paradox.markdown
+        |
+        |//#github-path-link
+        |object GithubPathLink {
+        |  //#github-neither-path-link
+        |  type Neither[A, B] = Nothing
+        |  //#github-neither-path-link
+        |}
+        |//#github-path-link
+        |
+        |//#example
+        |object example extends App {
+        |  println("Hello, World!")
+        |}
+        |//#example
+        |
+        |object IndentedExample {
+        |  //#indented-example
+        |  case object Dent
+        |  //#indented-example
+        |
+        |  object EventMore {
+        |    //#indented-example
+        |    case object DoubleDent
+        |    //#indented-example
+        |  }
+        |}
+        |
+        |//#multi-indented-example
+        |//#some-other-anchor
+        |object AnotherIndentedExample {
+        |  //#multi-indented-example
+        |
+        |  def notRendered(): Unit = {
+        |  }
+        |
+        |  //#multi-indented-example
+        |  def rendered(): Unit = {
+        |  }
+        |  //#some-other-anchor
+        |  //#multi-indented-example
+        |
+        |  def alsoNotRendered(): Unit = {
+        |
+        |  }
+        |  //#multi-indented-example
+        |}
+        |//#multi-indented-example
+        |
+        |//#multi-indented-example
+        |class AnotherClass
+        |//#multi-indented-example
+        |
+        |// check empty line with indented blocks!
+        |// format: OFF
+        |  //#multi-indented-example
+        |
+        |  //#multi-indented-example
+        |// format: ON
+        |
+        |
+        |//#example-with-label
+        |object Constants {
+        |  val someString = " #foo "
+        |}
+        |//#example-with-label</code>
+        |</pre>"""
+    )
+  }
+
   it should "filter labels by default" in {
     markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #example-with-label }""") shouldEqual html(
       """<pre class="prettyprint">


### PR DESCRIPTION
## Purpose

Disable label filtering for snippets/includes/fiddles which include a complete file.
Document the `filterLabels` flag and property. 

## Background 

Especially for snippets including whole HOCON files, label filtering often hides important lines with important information as `#` is used for comments.

One example is the `reference.conf` snippet in https://doc.akka.io/docs/alpakka/1.1.1/dynamodb.html#setup

