### PR TITLE
Remove unnecessary normalize stylesheet

### DIFF
--- a/plugin/src/sbt-test/paradox/default-theme/expected/index.html
+++ b/plugin/src/sbt-test/paradox/default-theme/expected/index.html
@@ -12,7 +12,6 @@
 <script type="text/javascript" src="js/page.js"></script>
 <script type="text/javascript" src="js/warnOldVersion.js"></script>
 <script type="text/javascript" src="js/groups.js"></script>
-<link rel="stylesheet" type="text/css" href="lib/normalize.css/normalize.css"/>
 <link rel="stylesheet" type="text/css" href="lib/foundation/dist/foundation.min.css"/>
 <link rel="stylesheet" type="text/css" href="css/page.css"/>
 

--- a/plugin/src/sbt-test/paradox/default-theme/expected/sub/indexed.html
+++ b/plugin/src/sbt-test/paradox/default-theme/expected/sub/indexed.html
@@ -12,7 +12,6 @@
 <script type="text/javascript" src="../js/page.js"></script>
 <script type="text/javascript" src="../js/warnOldVersion.js"></script>
 <script type="text/javascript" src="../js/groups.js"></script>
-<link rel="stylesheet" type="text/css" href="../lib/normalize.css/normalize.css"/>
 <link rel="stylesheet" type="text/css" href="../lib/foundation/dist/foundation.min.css"/>
 <link rel="stylesheet" type="text/css" href="../css/page.css"/>
 

--- a/plugin/src/sbt-test/paradox/default-theme/expected/sub/unindexed.html
+++ b/plugin/src/sbt-test/paradox/default-theme/expected/sub/unindexed.html
@@ -12,7 +12,6 @@
 <script type="text/javascript" src="../js/page.js"></script>
 <script type="text/javascript" src="../js/warnOldVersion.js"></script>
 <script type="text/javascript" src="../js/groups.js"></script>
-<link rel="stylesheet" type="text/css" href="../lib/normalize.css/normalize.css"/>
 <link rel="stylesheet" type="text/css" href="../lib/foundation/dist/foundation.min.css"/>
 <link rel="stylesheet" type="text/css" href="../css/page.css"/>
 

--- a/themes/generic/src/main/assets/page.st
+++ b/themes/generic/src/main/assets/page.st
@@ -14,7 +14,6 @@ $endif$
 <script type="text/javascript" src="$page.base$js/page.js"></script>
 <script type="text/javascript" src="$page.base$js/warnOldVersion.js"></script>
 <script type="text/javascript" src="$page.base$js/groups.js"></script>
-<link rel="stylesheet" type="text/css" href="$page.base$lib/normalize.css/normalize.css"/>
 <link rel="stylesheet" type="text/css" href="$page.base$lib/foundation/dist/foundation.min.css"/>
 <link rel="stylesheet" type="text/css" href="$page.base$css/page.css"/>
 


### PR DESCRIPTION
foundation.min.css already contains normalize concatenated in it:

https://developer.lightbend.com/docs/paradox/current/lib/foundation/dist/foundation.min.css

There's no need to pull it in. An example of a paradox site that doesn't pull it in and still works:

https://cloudstate.io/docs