### PR TITLE
Made javadoc link style configurable

### DIFF
--- a/docs/src/main/paradox/directives/linking.md
+++ b/docs/src/main/paradox/directives/linking.md
@@ -97,7 +97,15 @@ For example, given:
  - `javadoc.akka.http.base_url=http://doc.akka.io/japi/akka-http/10.0.0`
 
 Then `@javadoc[Http](akka.http.javadsl.Http#shutdownAllConnectionPools--)` will resolve to
-<http://doc.akka.io/japi/akka-http/10.0.0/akka/http/javadsl/Http.html#shutdownAllConnectionPools-->.
+<http://doc.akka.io/japi/akka-http/10.0.0/?akka/http/javadsl/Http.html#shutdownAllConnectionPools-->.
+
+The `@javadoc` directive offers two styles of linking, linking to the frames version of
+the apidocs, and linking to the non frames version. This can be controlled using the `javadoc.link_style`
+property, setting it to `frames` for frames style linking, where rendered links link to the frames
+version of the javadocs, passing the class in the query parameter, and `direct` for linking direct
+to the classes page. The link style defaults to `direct` if the `java.specification.version` system
+property indicates Java 9+, since the JDK 9 Javadoc tool does not generate framed api docs. Otherwise,
+for Java 1.8 and earlier, it defaults to `frames`.
 
 By default, `javadoc.java.base_url` is configured to the Javadoc
 associated with the `java.specification.version` system property.

--- a/plugin/src/sbt-test/paradox/parameterized-links/build.sbt
+++ b/plugin/src/sbt-test/paradox/parameterized-links/build.sbt
@@ -11,6 +11,7 @@ paradoxProperties in Compile ++= Map(
   "extref.akka-docs.base_url" -> s"http://doc.akka.io/docs/akka/$akkaVersion/%s.html",
   "scaladoc.akka.base_url" -> s"http://doc.akka.io/api/akka/$akkaVersion",
   "scaladoc.akka.http.base_url" -> s"http://doc.akka.io/api/akka-http/$akkaHttpVersion",
+  "javadoc.link_style" -> "frames",
   "javadoc.base_url" -> s"https://api.example.com/java",
   "javadoc.akka.base_url" -> s"http://doc.akka.io/japi/akka/$akkaVersion",
   "javadoc.akka.http.base_url" -> s"http://doc.akka.io/japi/akka-http/$akkaHttpVersion"

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/JavadocDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/JavadocDirectiveSpec.scala
@@ -16,12 +16,11 @@
 
 package com.lightbend.paradox.markdown
 
-import com.lightbend.paradox.tree.Tree.Location
-
 class JavadocDirectiveSpec extends MarkdownBaseSpec {
 
   implicit val context = writerContextWithProperties(
     "javadoc.base_url" -> "http://www.reactive-streams.org/reactive-streams-1.0.0-javadoc/",
+    "javadoc.link_style" -> "frames",
     "javadoc.java.base_url" -> "https://docs.oracle.com/javase/8/docs/api/",
     "javadoc.akka.base_url" -> "http://doc.akka.io/japi/akka/2.4.10",
     "javadoc.akka.http.base_url" -> "http://doc.akka.io/japi/akka-http/10.0.0/index.html",
@@ -91,6 +90,12 @@ class JavadocDirectiveSpec extends MarkdownBaseSpec {
         |  [Publisher]: org.reactivestreams.Publisher
       """.stripMargin) shouldEqual
       html("""<p>The <a href="http://www.reactive-streams.org/reactive-streams-1.0.0-javadoc/?org/reactivestreams/Publisher.html">Publisher</a> spec</p>""")
+  }
+
+  it should "support creating non frame style links" in {
+    val ctx = context.andThen(c => c.copy(properties = c.properties.updated("javadoc.link_style", "direct")))
+    markdown("@javadoc[Publisher](org.reactivestreams.Publisher)")(ctx) shouldEqual
+      html("""<p><a href="http://www.reactive-streams.org/reactive-streams-1.0.0-javadoc/org/reactivestreams/Publisher.html">Publisher</a></p>""")
   }
 
 }


### PR DESCRIPTION
Fixes #354

This allows generating javadoc links to javadocs generated by JDK9+.