### PR TITLE
Ensure paradoxBrowse works on Linux

### DIFF
--- a/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
+++ b/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
@@ -264,8 +264,15 @@ object ParadoxPlugin extends AutoPlugin {
 
   def openInBrowser(rootDocFile: File, log: Logger): Unit = {
     import java.awt.Desktop
-    if (Desktop.isDesktopSupported) Desktop.getDesktop.open(rootDocFile)
-    else log.info(s"Couldn't open default browser, but docs are at $rootDocFile")
+    def logCouldntOpen() = log.info(s"Couldn't open default browser, but docs are at $rootDocFile")
+    if (Desktop.isDesktopSupported && Desktop.getDesktop.isSupported(Desktop.Action.BROWSE)) Desktop.getDesktop.browse(rootDocFile.toURI)
+    // This should work for all XDG compliant desktop environments
+    else if (sys.env.contains("XDG_CURRENT_DESKTOP")) {
+      import sys.process._
+      if (Seq("xdg-open", rootDocFile.getAbsolutePath).! != 0) {
+        logCouldntOpen()
+      }
+    } else logCouldntOpen()
   }
 
 }


### PR DESCRIPTION
Documentation on exactly which platforms the AWT Desktop API works on is scarce, I read it's supposed to work on Gnome (and nothing else on Linux), but I'm using Gnome, and it doesn't work. This change falls back to using `xdg-open` if the `XDG_CURRENT_DESKTOP` environment variable is set, this should work on any desktop environment that supports the [XDG standard](https://www.freedesktop.org/wiki/Software/xdg-utils/), this includes Gnome, KDE, Unity, Xfce etc etc, so has much better support than the AWT Desktop API.

Also, this change also checks if the AWT Desktop API supports the AWT browse command. Apparently on some Linux platforms, the Desktop API is supported but browse isn't.