### PR TITLE
Support all sbt 1.x with sbt-paradox plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,6 +80,8 @@ lazy val plugin = project
     name := "sbt-paradox",
     sbtPlugin := true,
     addSbtPlugin(Library.sbtWeb),
+    pluginCrossBuild / sbtVersion := "1.0.0", // support all sbt 1.x
+    scriptedSbt := sbtVersion.value, // run scripted tests against build sbt by default
     scriptedLaunchOpts += ("-Dproject.version=" + version.value),
     scriptedLaunchOpts ++= ManagementFactory.getRuntimeMXBean.getInputArguments.asScala.filter(
       a => Seq("-Xmx", "-Xms", "-XX", "-Dfile").exists(a.startsWith)


### PR DESCRIPTION
Always build sbt-paradox with sbt 1.0.0 to be compatible with all sbt 1.x versions. Run the scripted tests against the build sbt by default (currently 1.3.0). We could also run the scripted tests against multiple sbt versions, but I haven't added that. I did check sbt 1.2.8 works again.