### PR TITLE
Fixed issues relating to JDK10 anchor link encoding

### DIFF
--- a/core/src/main/java/org/pegdown/ParserWithDirectives.java
+++ b/core/src/main/java/org/pegdown/ParserWithDirectives.java
@@ -18,6 +18,7 @@ package org.pegdown;
 
 import org.parboiled.Context;
 import org.parboiled.Rule;
+import org.parboiled.annotations.Cached;
 import org.parboiled.support.StringBuilderVar;
 import org.parboiled.support.Var;
 import org.pegdown.ast.*;
@@ -251,7 +252,11 @@ public class ParserWithDirectives extends Parser {
     }
 
     public Rule DirectDirectiveSource() {
-        return Sequence(Sp(), Enclosed('(', ANY, ')'), push(new DirectiveNode.Source.Direct(popAsString())));
+        return Sequence(
+                Sp(),
+                Enclosed('(', DirectiveLitChar(), ')'),
+                push(new DirectiveNode.Source.Direct(popAsString().replaceAll("\\\\(.)", "$1")))
+        );
     }
 
     public Rule RefDirectiveSource() {

--- a/docs/src/main/paradox/directives/linking.md
+++ b/docs/src/main/paradox/directives/linking.md
@@ -104,8 +104,20 @@ the apidocs, and linking to the non frames version. This can be controlled using
 property, setting it to `frames` for frames style linking, where rendered links link to the frames
 version of the javadocs, passing the class in the query parameter, and `direct` for linking direct
 to the classes page. The link style defaults to `direct` if the `java.specification.version` system
-property indicates Java 9+, since the JDK 9 Javadoc tool does not generate framed api docs. Otherwise,
-for Java 1.8 and earlier, it defaults to `frames`.
+property indicates Java 11+, since by in JDK 11, the Javadoc tool does not generate framed api docs. 
+Otherwise, for Java 10 and earlier, it defaults to `frames`.
+
+From JDK 10 onwards, anchors for Javadoc method references do not have `(`, `)` and `,` characters
+replaced with `-`. To facilitate in migrating, Paradox supports automatically converting between
+escaped and unescaped anchor styles. Simply set the javadoc version for the package, using 
+`javadoc.<package-prefix>.javadoc_version`. For example, given this setting:
+
+ - `javadoc.java.javadoc_version=11`
+ 
+This will cause an anchor like `java.util.Map#put-K-V-` to be rendered as `java/util/Map.html#put(K,V)`.
+
+Additionally, the value of `detect` is accepted, which will detect the version from `java.specification.version`.
+This can be useful when doing link validation with javadocs built by the same build.
 
 By default, `javadoc.java.base_url` is configured to the Javadoc
 associated with the `java.specification.version` system property.

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/JavadocDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/JavadocDirectiveSpec.scala
@@ -27,7 +27,11 @@ class JavadocDirectiveSpec extends MarkdownBaseSpec {
     "javadoc.akka.base_url" -> "http://doc.akka.io/japi/akka/2.4.10",
     "javadoc.akka.http.base_url" -> "http://doc.akka.io/japi/akka-http/10.0.0/index.html",
     "javadoc.root.relative.base_url" -> ".../javadoc/api/",
-    "javadoc.broken.base_url" -> "https://c|"
+    "javadoc.broken.base_url" -> "https://c|",
+    "javadoc.jdk11.base_url" -> "jdk11api/",
+    "javadoc.jdk11.javadoc_version" -> "11",
+    "javadoc.jdk8.base_url" -> "jdk8api/",
+    "javadoc.jdk8.javadoc_version" -> "1.8"
   )
 
   "javadoc directive" should "create links using configured URL templates" in {
@@ -92,6 +96,26 @@ class JavadocDirectiveSpec extends MarkdownBaseSpec {
         |  [Publisher]: org.reactivestreams.Publisher
       """.stripMargin) shouldEqual
       html("""<p>The <a href="http://www.reactive-streams.org/reactive-streams-1.0.0-javadoc/?org/reactivestreams/Publisher.html">Publisher</a> spec</p>""")
+  }
+
+  it should "convert jdk10+ javadoc anchor link styles to jdk8 if explicitly requested" in {
+    markdown("@javadoc[Model](jdk8.Model#method\\(java.lang.Object,int\\))") shouldEqual
+      html("""<p><a href="jdk8api/?jdk8/Model.html#method-java.lang.Object-int-">Model</a></p>""")
+  }
+
+  it should "leave jdk8 javadoc anchor link styles alone if jdk8 is explicitly requested" in {
+    markdown("@javadoc[Model](jdk8.Model#method-java.lang.Object-int-)") shouldEqual
+      html("""<p><a href="jdk8api/?jdk8/Model.html#method-java.lang.Object-int-">Model</a></p>""")
+  }
+
+  it should "convert jdk8 javadoc anchor link styles if jdk10+ is explicitly requested" in {
+    markdown("@javadoc[Model](jdk11.Model#method-java.lang.Object-int-)") shouldEqual
+      html("""<p><a href="jdk11api/?jdk11/Model.html#method(java.lang.Object,int)">Model</a></p>""")
+  }
+
+  it should "leave jdk10+ javadoc anchor link styles alone if jdk10+ is explicitly requested" in {
+    markdown("@javadoc[Model](jdk11.Model#method\\(java.lang.Object,int\\))") shouldEqual
+      html("""<p><a href="jdk11api/?jdk11/Model.html#method(java.lang.Object,int)">Model</a></p>""")
   }
 
   it should "support creating non frame style links" in {


### PR DESCRIPTION
In JDK10 onwards, the way that anchor links for methods are encoded has changed, compare:

```
https://docs.oracle.com/javase/10/docs/api/java/util/Map.html#put(K,V)
 https://docs.oracle.com/javase/9/docs/api/java/util/Map.html#put-K-V-
```

This adds functionality to paradox to automatically convert between the two styles, by saying `javadoc.javadoc_version = 11` for example. The setting applies per path prefix, and if unset, no conversion is done. A special value of `detect` is supported, to allow converting based on the builds java version.