### PR TITLE
Allow matching parenthese pairs to occur inside of directive sou…

### DIFF
--- a/core/src/main/java/org/pegdown/ParserWithDirectives.java
+++ b/core/src/main/java/org/pegdown/ParserWithDirectives.java
@@ -18,6 +18,7 @@ package org.pegdown;
 
 import org.parboiled.Context;
 import org.parboiled.Rule;
+import org.parboiled.annotations.Cached;
 import org.parboiled.support.StringBuilderVar;
 import org.parboiled.support.Var;
 import org.pegdown.ast.*;
@@ -265,8 +266,22 @@ public class ParserWithDirectives extends Parser {
     public Rule Enclosed(char start, Rule matching, char end) {
         return Sequence(
             start,
-            Sequence(ZeroOrMore(TestNot(end), NotNewline(), matching), push(match())),
+            Sequence(ZeroOrMore(EnclosedSnippet(start, matching, end)), push(match())),
             end
+        );
+    }
+
+    @SuppressWarnings( {"InfiniteRecursion"})
+    @Cached
+    /* Counts start/end pairs so the enclosing chars can occur inside of an Enclosed block if matched */
+    public Rule EnclosedSnippet(char start, Rule matching, char end) {
+        return FirstOf(
+            Sequence(TestNot(start), TestNot(end), NotNewline(), matching),
+            Sequence(
+                start,
+                ZeroOrMore(EnclosedSnippet(start, matching, end)),
+                end
+            )
         );
     }
 

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/JavadocDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/JavadocDirectiveSpec.scala
@@ -50,6 +50,11 @@ class JavadocDirectiveSpec extends MarkdownBaseSpec {
       html("""<p><a href="https://docs.oracle.com/javase/8/docs/api/?java/io/File.html#pathSeparator" title="java.io.File"><code>File.pathSeparator</code></a></p>""")
   }
 
+  it should "handle method links with parentheses correctly" in {
+    markdown("@javadoc[File.pathSeparator](java.io.File#method())") shouldEqual
+      html("""<p><a href="https://docs.oracle.com/javase/8/docs/api/?java/io/File.html#method()" title="java.io.File"><code>File.pathSeparator</code></a></p>""")
+  }
+
   it should "handle class links correctly" in {
     markdown("@javadoc[Http](akka.http.javadsl.Http)") shouldEqual
       html("""<p><a href="http://doc.akka.io/japi/akka-http/10.0.0/index.html?akka/http/javadsl/Http.html" title="akka.http.javadsl.Http"><code>Http</code></a></p>""")


### PR DESCRIPTION
This is especially useful inside of `@javadoc` directives that go to JDK 10
style method anchors which can contain parentheses in the anchor.

It's an alternative to #368 that actually allows nested parentheses.