### PR TITLE
Fix default javadoc base for jdk11+

### DIFF
--- a/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
+++ b/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
@@ -275,9 +275,12 @@ object ParadoxPlugin extends AutoPlugin {
     val JavaSpecVersion = """\d+\.(\d+)""".r
     Map(
       "javadoc.java.base_url" -> sys.props.get("java.specification.version").map {
-        case JavaSpecVersion(v) => v
-        case v                  => v
-      }.map { v => url(s"https://docs.oracle.com/javase/$v/docs/api/") },
+        case JavaSpecVersion(v) => v.toInt
+        case v                  => v.toInt
+      }.map { v =>
+        if (v < 11) url(s"https://docs.oracle.com/javase/$v/docs/api/")
+        else url(s"https://docs.oracle.com/en/java/javase/$v/docs/api/")
+      },
       "scaladoc.version" -> Some(scalaVersion),
       "scaladoc.scala.base_url" -> Some(url(s"http://www.scala-lang.org/api/$scalaVersion")),
       "scaladoc.base_url" -> apiURL,


### PR DESCRIPTION
Kind of dodgy that we rely on sys.props.get("java.specification.version")
but ok.