### PR TITLE
Dependency directive: symbolic version numbers

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -826,8 +826,8 @@ case class DependencyDirective(ctx: Writer.Context) extends LeafBlockDirective("
           val symbolProperties = if (symbols.isEmpty) "" else
             symbolPostfixes.map { sp =>
               val symb = s"""${requiredCoordinate(VersionSymbol + sp)}"""
-              s"""  &lt;$symb&gt;${requiredCoordinate(VersionValue + sp)}&lt;/$symb&gt;\n"""
-            }.mkString("&lt;properties&gt;\n", "\n", "&lt;/properties&gt;\n")
+              s"""  &lt;$symb&gt;${requiredCoordinate(VersionValue + sp)}&lt;/$symb&gt;"""
+            }.mkString("&lt;properties&gt;\n", "\n", "\n&lt;/properties&gt;\n")
           val artifacts = dependencyPostfixes.map { dp =>
             mvn(
               requiredCoordinate(s"group$dp"),

--- a/docs/src/main/paradox/directives/dependencies.md
+++ b/docs/src/main/paradox/directives/dependencies.md
@@ -44,6 +44,8 @@ Which will render as:
   classifier="assets"
 }
 
+## Multiple dependencies
+
 It is also possible to render more than one dependency in a list. In that case library coordinates need to be appended with the
 same suffix. For example
 
@@ -59,4 +61,44 @@ will be rendered as:
 @@dependency[sbt,Maven,Gradle] {
   group="com.example" artifact="domain" version="0.1.0"
   group2="com.example" artifact2="another-domain" version2="0.2.1"
+}
+
+## Symbolic version numbers
+
+When multiple dependencies always use the same version, symbolic version names can be shown. For example
+
+```scala
+@@dependency[sbt,Maven,gradle] {
+  symbol="AkkaVersion"
+  value="2.5.29"
+  symbol2="AkkaHttpVersion"
+  value2="10.1.0"
+  group="com.typesafe.akka"
+  artifact="akka-stream_$scala.binary.version$"
+  version="AkkaVersion"
+  group2="com.typesafe.akka"
+  artifact2="akka-actor-typed_$scala.binary.version$"
+  version2="AkkaVersion"
+  group3="com.typesafe.akka"
+  artifact3="akka-http_$scala.binary.version$"
+  version3="AkkaHttpVersion"
+}
+```
+
+will be rendered as:
+
+@@dependency[sbt,Maven,gradle] {
+  symbol="AkkaVersion"
+  value="2.5.29"
+  symbol2="AkkaHttpVersion"
+  value2="10.1.0"
+  group="com.typesafe.akka"
+  artifact="akka-stream_$scala.binary.version$"
+  version="AkkaVersion"
+  group2="com.typesafe.akka"
+  artifact2="akka-actor-typed_$scala.binary.version$"
+  version2="AkkaVersion"
+  group3="com.typesafe.akka"
+  artifact3="akka-http_$scala.binary.version$"
+  version3="AkkaHttpVersion"
 }

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/DependencyDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/DependencyDirectiveSpec.scala
@@ -232,7 +232,7 @@ class DependencyDirectiveSpec extends MarkdownBaseSpec {
       """)
   }
 
-  it should "render version values for sbt" in {
+  it should "render symbolic version values" in {
     markdown("""
                |@@dependency[sbt,Maven,gradle] {
                |  symbol="AkkaHttpVersion"
@@ -270,6 +270,68 @@ class DependencyDirectiveSpec extends MarkdownBaseSpec {
       |  AkkaHttpVersion: "10.1.0"
       |]
       |dependencies {
+      |  compile group: 'com.typesafe.akka', name: 'akka-http_2.12', version: versions.AkkaHttpVersion
+      |}</code>
+      |</pre>
+      |</dd>
+      |</dl>""")
+  }
+
+  it should "render multiple symbolic version values" in {
+    markdown("""
+               |@@dependency[sbt,Maven,gradle] {
+               |  symbol="AkkaVersion"
+               |  value="2.5.29"
+               |  symbol2="AkkaHttpVersion"
+               |  value2="10.1.0"
+               |  group="com.typesafe.akka"
+               |  artifact="akka-stream_$scala.binary.version$"
+               |  version="AkkaVersion"
+               |  group2="com.typesafe.akka"
+               |  artifact2="akka-http_$scala.binary.version$"
+               |  version2="AkkaHttpVersion"
+               |}""") shouldEqual html(s"""
+      |<dl class="dependency">
+      |<dt>sbt</dt>
+      |<dd>
+      |<pre class="prettyprint">
+      |<code class="language-scala">
+      |val AkkaVersion = "2.5.29"
+      |val AkkaHttpVersion = "10.1.0"
+      |libraryDependencies ++= Seq(
+      |  "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+      |  "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion
+      |)</code></pre>
+      |</dd>
+      |<dt>Maven</dt>
+      |<dd>
+      |<pre class="prettyprint">
+      |<code class="language-xml">
+      |&lt;properties&gt;
+      |  &lt;AkkaVersion&gt;2.5.29&lt;/AkkaVersion&gt;
+      |  &lt;AkkaHttpVersion&gt;10.1.0&lt;/AkkaHttpVersion&gt;
+      |&lt;/properties&gt;
+      |&lt;dependency&gt;
+      |  &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
+      |  &lt;artifactId&gt;akka-stream_2.12&lt;/artifactId&gt;
+      |  &lt;version&gt;$${AkkaVersion}&lt;/version&gt;
+      |&lt;/dependency&gt;
+      |&lt;dependency&gt;
+      |  &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
+      |  &lt;artifactId&gt;akka-http_2.12&lt;/artifactId&gt;
+      |  &lt;version&gt;$${AkkaHttpVersion}&lt;/version&gt;
+      |&lt;/dependency&gt;</code></pre>
+      |</dd>
+      |<dt>gradle</dt>
+      |<dd>
+      |<pre class="prettyprint">
+      |<code class="language-gradle">
+      |versions += [
+      |  AkkaVersion: "2.5.29",
+      |  AkkaHttpVersion: "10.1.0"
+      |]
+      |dependencies {
+      |  compile group: 'com.typesafe.akka', name: 'akka-stream_2.12', version: versions.AkkaVersion,
       |  compile group: 'com.typesafe.akka', name: 'akka-http_2.12', version: versions.AkkaHttpVersion
       |}</code>
       |</pre>

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/DependencyDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/DependencyDirectiveSpec.scala
@@ -231,4 +231,49 @@ class DependencyDirectiveSpec extends MarkdownBaseSpec {
       |</dl>
       """)
   }
+
+  it should "render version values for sbt" in {
+    markdown("""
+               |@@dependency[sbt,Maven,gradle] {
+               |  symbol="AkkaHttpVersion"
+               |  value="10.1.0"
+               |  group="com.typesafe.akka"
+               |  artifact="akka-http_$scala.binary.version$"
+               |  version="AkkaHttpVersion"
+               |}""") shouldEqual html(s"""
+      |<dl class="dependency">
+      |<dt>sbt</dt>
+      |<dd>
+      |<pre class="prettyprint">
+      |<code class="language-scala">
+      |val AkkaHttpVersion = "10.1.0"
+      |libraryDependencies += "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion</code></pre>
+      |</dd>
+      |<dt>Maven</dt>
+      |<dd>
+      |<pre class="prettyprint">
+      |<code class="language-xml">
+      |&lt;properties&gt;
+      |  &lt;AkkaHttpVersion&gt;10.1.0&lt;/AkkaHttpVersion&gt;
+      |&lt;/properties&gt;
+      |&lt;dependency&gt;
+      |  &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
+      |  &lt;artifactId&gt;akka-http_2.12&lt;/artifactId&gt;
+      |  &lt;version&gt;$${AkkaHttpVersion}&lt;/version&gt;
+      |&lt;/dependency&gt;</code></pre>
+      |</dd>
+      |<dt>gradle</dt>
+      |<dd>
+      |<pre class="prettyprint">
+      |<code class="language-gradle">
+      |versions += [
+      |  AkkaHttpVersion: "10.1.0"
+      |]
+      |dependencies {
+      |  compile group: 'com.typesafe.akka', name: 'akka-http_2.12', version: versions.AkkaHttpVersion
+      |}</code>
+      |</pre>
+      |</dd>
+      |</dl>""")
+  }
 }


### PR DESCRIPTION
Support symbolic version numbers to be rendered in the dependency listing.
This may help Akka users to get all of their Akka dependencies to use the exact same version.

While the notation might not be fully idiomatic for Maven and Gradle, it gets the point across.

![image](https://user-images.githubusercontent.com/458526/74721312-77836480-5237-11ea-8870-7c4b6ea6a367.png)

![image](https://user-images.githubusercontent.com/458526/74721328-7f430900-5237-11ea-8260-3b2d6e56fe26.png)

![image](https://user-images.githubusercontent.com/458526/74721469-b87b7900-5237-11ea-97ca-e064fa50d049.png)
