### PR TITLE
plugin: allow configuration of maxParsingTimeout

### DIFF
--- a/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxKeys.scala
+++ b/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxKeys.scala
@@ -21,6 +21,7 @@ import com.lightbend.paradox.ParadoxProcessor
 import com.lightbend.paradox.markdown.{ Directive, Writer }
 import com.lightbend.paradox.template.PageTemplate
 
+import scala.concurrent.duration.Duration
 import scala.util.matching.Regex
 
 trait ParadoxKeys {
@@ -37,6 +38,7 @@ trait ParadoxKeys {
   val paradoxOrganization = settingKey[String]("Paradox dependency organization (for theme dependencies).")
   val paradoxDirectives = taskKey[Seq[Writer.Context => Directive]]("Enabled paradox directives.")
   val paradoxProcessor = taskKey[ParadoxProcessor]("ParadoxProcessor to use when generating the site.")
+  val paradoxParsingTimeout = settingKey[Duration]("Per-page pegdown parsing timeout. Parsing will fail if it takes longer than this (safe-guard for parser non-termination).")
   val paradoxProperties = taskKey[Map[String, String]]("Property map passed to paradox.")
   val paradoxSourceSuffix = settingKey[String]("Source file suffix for markdown files [default = \".md\"].")
   val paradoxTargetSuffix = settingKey[String]("Target file suffix for HTML files [default = \".html\"].")

--- a/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
+++ b/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala
@@ -16,6 +16,7 @@
 
 package com.lightbend.paradox.sbt
 
+import com.lightbend.paradox.markdown.Reader
 import sbt._
 import sbt.Keys._
 import sbt.Defaults.generate
@@ -25,6 +26,7 @@ import com.lightbend.paradox.template.PageTemplate
 import com.typesafe.sbt.web.Import.{ Assets, WebKeys }
 import com.typesafe.sbt.web.{ SbtWeb, Compat => WCompat }
 
+import scala.concurrent.duration._
 import scala.sys.process.ProcessLogger
 
 object ParadoxPlugin extends AutoPlugin {
@@ -53,6 +55,7 @@ object ParadoxPlugin extends AutoPlugin {
     paradoxNavigationDepth := 2,
     paradoxNavigationExpandDepth := None,
     paradoxNavigationIncludeHeaders := false,
+    paradoxParsingTimeout := 2.seconds,
     paradoxExpectedNumberOfRoots := 1,
     paradoxRoots := List("index.html"),
     paradoxDirectives := Writer.defaultDirectives,
@@ -76,7 +79,9 @@ object ParadoxPlugin extends AutoPlugin {
   def baseParadoxSettings: Seq[Setting[_]] = Seq(
     WebKeys.webJarsClassLoader in Assets := classLoader((dependencyClasspath in ParadoxTheme).value),
 
-    paradoxProcessor := new ParadoxProcessor(writer = new Writer(serializerPlugins = Writer.defaultPlugins(paradoxDirectives.value))),
+    paradoxProcessor := new ParadoxProcessor(
+      reader = new Reader(maxParsingTime = paradoxParsingTimeout.value),
+      writer = new Writer(serializerPlugins = Writer.defaultPlugins(paradoxDirectives.value))),
 
     sourceDirectory := {
       val config = configuration.value


### PR DESCRIPTION
We've seen Travis builds fail because of parsing timeouts of relatively simply pages. The most likely reason is just general slowness of Travis probably paired with slow GC.

Example: https://github.com/akka/akka-http/issues/3429

The timeout is mostly there because parboiled can get really slow (non-terminating?) in edge cases so increasing it shouldn't affect well-formatted pages but will help when the build machine is slow.