### PR TITLE
Fix snippet label regex to allow `w`

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/markdown/Snippet.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Snippet.scala
@@ -86,7 +86,7 @@ object Snippet {
     // A label can be followed by an end of line or one or more spaces followed by an
     // optional single sequence of contiguous (no whitespace) non-word characters
     // (anything not in the group [a-zA-Z0-9_])
-    val labelPattern = ("""#\Q""" + label + """\E( +[^w \t]*)?$""").r
+    val labelPattern = ("""#\Q""" + label + """\E( +[^\w \t]*)?$""").r
     val hasLabel = (s: String) => labelPattern.findFirstIn(s).nonEmpty
     val extractionState = extractFrom(lines, hasLabel, hasLabel, addFilteredLine(filterLabelLines))
     if (extractionState.snippetLines.isEmpty)
@@ -133,7 +133,7 @@ object Snippet {
   private case object NoBlock extends Block
   private case object InBlock extends Block
 
-  private val anyLabelRegex = """#[a-zA-Z_0-9\-]+( +[^w \t]*)?$""".r
+  private val anyLabelRegex = """#[a-zA-Z_0-9\-]+( +[^\w \t]*)?$""".r
 
   private def containsLabel(line: String): Option[String] =
     anyLabelRegex.findFirstIn(line)

--- a/plugin/src/sbt-test/paradox/snippets/src/test/scala/Snippets.scala
+++ b/plugin/src/sbt-test/paradox/snippets/src/test/scala/Snippets.scala
@@ -5,9 +5,9 @@ object Snippets {
   }
   // #indented
 
-  //#symbols-at-eol        ¯\_(ツ)_/¯
+  //#symbols-at-eol        ¯\(ツ)/¯
   val symbols = Seq('symbols, Symbol("@"), 'EOL)
-  //#symbols-at-eol        ¯\_(ツ)_/¯
+  //#symbols-at-eol        ¯\(ツ)/¯
 
   //#space-after-marker
   val spacy = "Please do not remove ending spaces after these markers"


### PR DESCRIPTION
Discovered that the snippet label matching was incorrect, when trying examples shared by both paradox and asciidoc — having both paradox labels and asciidoc tags in the same comment worked, apart from when the tag contained a lowercase `w`. Original intention was for this to not be possible, with either the label at the end of the line, or followed only by whitespace then non-word characters.

Added the missing backslash. The unicode shrug in the test can no longer have underscores.