### PR TITLE
Dependency directive: produce BOM notation, modern Gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 
 env:
   matrix:
-    - TRAVIS_JDK=adopt@1.8.0-222
+    - TRAVIS_JDK=adopt@1.8-0
 
 before_install: curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
 install: jabba install "$TRAVIS_JDK" && jabba use $_ && java -Xmx32m -version
@@ -19,7 +19,7 @@ jobs:
 
     - script: sbt verify
       name: "Compile, test and build docs with JDK11"
-      env: TRAVIS_JDK=adopt@1.11.0-4
+      env: TRAVIS_JDK=adopt@1.11-0
 
     - stage: publish
       script: sbt ci-release
@@ -48,7 +48,3 @@ cache:
 before_cache:
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
   - find $HOME/.sbt        -name "*.lock"               -print -delete
-
-notifications:
-  email:
-    on_success: never

--- a/README.markdown
+++ b/README.markdown
@@ -1,12 +1,10 @@
-Paradox [![scaladex-badge][]][scaladex] [![travis-badge][]][travis] [![gitter-badge][]][gitter]
+Paradox [![scaladex-badge][]][scaladex] [![travis-badge][]][travis]
 =======
 
 [scaladex]:       https://index.scala-lang.org/lightbend/paradox
 [scaladex-badge]: https://index.scala-lang.org/lightbend/paradox/paradox/latest.svg
-[travis]:                https://travis-ci.org/lightbend/paradox
-[travis-badge]:          https://travis-ci.org/lightbend/paradox.svg?branch=master
-[gitter]:                    https://gitter.im/lightbend/paradox
-[gitter-badge]:       https://badges.gitter.im/lightbend/paradox.svg
+[travis]:                https://travis-ci.com/lightbend/paradox
+[travis-badge]:          https://travis-ci.com/lightbend/paradox.svg?branch=master
 
 Paradox is a markdown documentation tool for software projects. See [Paradox docs](http://developer.lightbend.com/docs/paradox/latest/) for details.
 
@@ -18,4 +16,4 @@ This software is licensed under the Apache 2 license.
 
 **Paradox is NOT supported under the Lightbend subscription.**
 
-The project is maintained by the [Paradox Team](https://github.com/orgs/lightbend/teams/paradox) and all [the contributors](https://github.com/lightbend/paradox/graphs/contributors). Pull requests are very welcome–thanks in advance!
+The project is community maintained by [the contributors](https://github.com/lightbend/paradox/graphs/contributors). Pull requests are very welcome–thanks in advance!

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -792,7 +792,11 @@ case class DependencyDirective(ctx: Writer.Context) extends LeafBlockDirective("
 
     def gradle(group: String, artifact: String, rawArtifact: String, version: Option[String], scope: Option[String], classifier: Option[String]): String = {
       val artifactName = artifactNameWithScalaBin(artifact, rawArtifact, "${versions.ScalaBinary}")
-      val conf = scope.getOrElse("implementation")
+      val conf = scope match {
+        case None         => "implementation"
+        case Some("test") => "testImplementation"
+        case Some(other)  => other
+      }
       val ver = version.map(v => if (symbols.contains(v)) s":$${versions.$v}" else s":$v").getOrElse("")
       val extra = classifier.map(c => s":$c").getOrElse("")
       s"""$conf "$group:$artifactName$ver$extra""""

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -696,6 +696,7 @@ case class InlineGroupDirective(groups: Seq[String]) extends InlineDirective(gro
  * Dependency directive.
  */
 case class DependencyDirective(ctx: Writer.Context) extends LeafBlockDirective("dependency") {
+  val BomVersionSymbol = "bomVersionSymbol"
   val VersionSymbol = "symbol"
   val VersionValue = "value"
   val ScalaBinaryVersionVar = "scala.binary.version"
@@ -713,6 +714,9 @@ case class DependencyDirective(ctx: Writer.Context) extends LeafBlockDirective("
 
   def renderDependency(tools: String, node: DirectiveNode, printer: Printer): Unit = {
     val classes = Seq("dependency", node.attributes.classesString).filter(_.nonEmpty)
+
+    val bomPostfixes = node.attributes.keys().asScala.toSeq
+      .filter(_.startsWith(BomVersionSymbol)).sorted.map(_.replace(BomVersionSymbol, ""))
 
     val symbolPostfixes = node.attributes.keys().asScala.toSeq
       .filter(_.startsWith(VersionSymbol)).sorted.map(_.replace(VersionSymbol, ""))
@@ -775,34 +779,56 @@ case class DependencyDirective(ctx: Writer.Context) extends LeafBlockDirective("
       }
     }
 
-    def gradle(group: String, artifact: String, rawArtifact: String, version: String, scope: Option[String], classifier: Option[String]): String = {
-      val artifactName = ScalaBinaryVersion match {
+    /**
+     * Replace Scala bin version in artifact postfix with the property.
+     */
+    def artifactNameWithScalaBin(artifact: String, rawArtifact: String, property: String) = {
+      ScalaBinaryVersion match {
         case Some(v) if (rawArtifact.endsWith(scalaBinaryVersionVarUse)) =>
-          "\"" + artifact.substring(0, artifact.length - v.length) + "${versions.ScalaBinary}\""
-        case _ => s"'$artifact'"
-      }
-      val conf = scope.getOrElse("compile")
-      val extra = classifier.map(c => s", classifier: '$c'").getOrElse("")
-      val v = if (symbols.contains(version)) s"versions.$version" else s"'$version'"
-      s"""$conf group: '$group', name: $artifactName, version: $v$extra""".stripMargin
-    }
-
-    def mvn(group: String, artifact: String, rawArtifact: String, version: String, scope: Option[String], classifier: Option[String]): String = {
-      val artifactName = ScalaBinaryVersion match {
-        case Some(v) if rawArtifact.endsWith(scalaBinaryVersionVarUse) =>
-          artifact.substring(0, artifact.length - v.length) + "${scala.binary.version}"
+          artifact.substring(0, artifact.length - v.length) + property
         case _ => artifact
       }
+    }
+
+    def gradle(group: String, artifact: String, rawArtifact: String, version: Option[String], scope: Option[String], classifier: Option[String]): String = {
+      val artifactName = artifactNameWithScalaBin(artifact, rawArtifact, "${versions.ScalaBinary}")
+      val conf = scope.getOrElse("implementation")
+      val ver = version.map(v => if (symbols.contains(v)) s":$${versions.$v}" else s":$v").getOrElse("")
+      val extra = classifier.map(c => s":$c").getOrElse("")
+      s"""$conf "$group:$artifactName$ver$extra""""
+    }
+
+    def gradleBom(group: String, artifact: String, rawArtifact: String, version: String): String = {
+      val artifactName = artifactNameWithScalaBin(artifact, rawArtifact, "${versions.ScalaBinary}")
+      val ver = if (symbols.contains(version)) s"versions.$version" else version
+      s"""  implementation platform("$group:$artifactName:$ver")"""
+    }
+
+    def mvn(group: String, artifact: String, rawArtifact: String, version: Option[String], `type`: Option[String], scope: Option[String], classifier: Option[String], indent: String): String = {
+      val artifactName = artifactNameWithScalaBin(artifact, rawArtifact, "${scala.binary.version}")
 
       val elements =
-        Seq("groupId" -> group, "artifactId" -> artifactName, "version" -> {
-          if (symbols.contains(version)) s"$${${dotted(version)}}" else version
-        }) ++
-          classifier.map("classifier" -> _) ++ scope.map("scope" -> _)
+        Seq("groupId" -> group, "artifactId" -> artifactName) ++
+          version.map(v => "version" -> {
+            if (symbols.contains(v)) s"$${${dotted(v)}}" else v
+          }) ++ classifier.map("classifier" -> _) ++ `type`.map("type" -> _) ++ scope.map("scope" -> _)
       elements.map {
-        case (element, value) => s"  <$element>$value</$element>"
-      }.mkString("<dependency>\n", "\n", "\n</dependency>").replace("<", "&lt;").replace(">", "&gt;")
+        case (element, value) => s"$indent  &lt;$element&gt;$value&lt;/$element&gt;"
+      }.mkString(s"$indent&lt;dependency&gt;\n", "\n", s"\n$indent&lt;/dependency&gt\n")
     }
+
+    val boms = bomPostfixes.map { p =>
+      (
+        requiredCoordinate(s"bomGroup$p"),
+        requiredCoordinate(s"bomArtifact$p"),
+        requiredCoordinateRaw(s"bomArtifact$p"),
+        requiredCoordinate(s"bomVersionSymbol$p")
+      )
+    }
+    val bomSymbols = boms.map(_._4).toSet
+
+    val symbolVersions = symbolPostfixes
+      .map(sp => requiredCoordinate(VersionSymbol + sp) -> requiredCoordinate(VersionValue + sp))
 
     printer.print(s"""<dl class="${classes.mkString(" ")}">""")
     tools.split("[,]").map(_.trim).filter(_.nonEmpty).foreach { tool =>
@@ -831,54 +857,89 @@ case class DependencyDirective(ctx: Writer.Context) extends LeafBlockDirective("
 
         case "gradle" | "Gradle" =>
           val scalaBinaryVersionProperties =
-            if (showSymbolScalaBinary) ScalaBinaryVersion.flatMap { v =>
-              Some(s"""  ScalaBinary: "$v"""")
-            }
+            if (showSymbolScalaBinary) ScalaBinaryVersion.map(v => s"""  ScalaBinary: "$v"""")
             else None
           val symbolProperties = if (scalaBinaryVersionProperties.isEmpty && symbols.isEmpty) "" else
-            (symbolPostfixes.map { sp =>
-              s"""  ${requiredCoordinate(VersionSymbol + sp)}: "${requiredCoordinate(VersionValue + sp)}""""
-            } ++ scalaBinaryVersionProperties).mkString("versions += [\n", ",\n", "\n]\n")
+            (symbolVersions
+              .filter(sp => !bomSymbols.contains(sp._1))
+              .map {
+                case (symbol, version) => s"""  $symbol: "$version""""
+              } ++ scalaBinaryVersionProperties).mkString("def versions = [\n", ",\n", "\n]\n")
+          val bomArtifacts =
+            if (boms.nonEmpty) {
+              boms.map {
+                case (group, artifact, artifactRaw, versionSymbol) =>
+                  gradleBom(
+                    group,
+                    artifact,
+                    artifactRaw,
+                    version = symbolVersions.find(_._1 == versionSymbol).map(_._2).getOrElse(sys.error(s"No version found for $versionSymbol")),
+                  )
+              }.mkString("", "\n", "\n\n")
+            } else ""
           val artifacts = dependencyPostfixes.map { dp =>
+            val versionCoordinate = requiredCoordinate(s"version$dp")
             gradle(
               requiredCoordinate(s"group$dp"),
               requiredCoordinate(s"artifact$dp"),
               requiredCoordinateRaw(s"artifact$dp"),
-              requiredCoordinate(s"version$dp"),
+              if (bomSymbols.contains(versionCoordinate)) None else Some(versionCoordinate),
               coordinate(s"scope$dp"),
               coordinate(s"classifier$dp")
             )
           }
 
           val libraryDependencies =
-            Seq("dependencies {", artifacts.map(a => s"  $a").mkString(",\n"), "}").mkString("\n")
+            Seq("dependencies {", bomArtifacts ++ artifacts.map(a => s"  $a").mkString("\n"), "}").mkString("\n")
 
           ("gradle", symbolProperties + libraryDependencies)
 
         case "maven" | "Maven" | "mvn" =>
           val scalaBinaryVersionProperties =
-            if (showSymbolScalaBinary) ScalaBinaryVersion.flatMap { v =>
-              Some(s"""  &lt;scala.binary.version&gt;$v&lt;/scala.binary.version&gt;""")
+            if (showSymbolScalaBinary) ScalaBinaryVersion.map { v =>
+              s"""  &lt;scala.binary.version&gt;$v&lt;/scala.binary.version&gt;"""
             }
             else None
           val symbolProperties = if (scalaBinaryVersionProperties.isEmpty && symbols.isEmpty) "" else
-            (symbolPostfixes.map { sp =>
-              val symb = s"""${dotted(requiredCoordinate(VersionSymbol + sp))}"""
-              s"""  &lt;$symb&gt;${requiredCoordinate(VersionValue + sp)}&lt;/$symb&gt;"""
-            } ++ scalaBinaryVersionProperties)
+            (symbolVersions
+              .filter(sp => !bomSymbols.contains(sp._1))
+              .map {
+                case (symbol, version) =>
+                  val symb = dotted(symbol)
+                  s"""  &lt;$symb&gt;$version&lt;/$symb&gt;"""
+              } ++ scalaBinaryVersionProperties)
               .mkString("&lt;properties&gt;\n", "\n", "\n&lt;/properties&gt;\n")
+          val bomArtifacts =
+            if (boms.nonEmpty) {
+              boms.map {
+                case (group, artifact, artifactRaw, versionSymbol) =>
+                  mvn(
+                    group,
+                    artifact,
+                    artifactRaw,
+                    version = symbolVersions.find(_._1 == versionSymbol).map(_._2),
+                    `type` = Some("pom"),
+                    scope = Some("import"),
+                    classifier = None,
+                    indent = "    "
+                  )
+              }.mkString("&lt;dependencyManagement&gt;\n  &lt;dependencies&gt;\n", "", "  &lt;/dependencies&gt;\n&lt;/dependencyManagement&gt;\n")
+            } else ""
           val artifacts = dependencyPostfixes.map { dp =>
+            val versionCoordinate = requiredCoordinate(s"version$dp")
             mvn(
               requiredCoordinate(s"group$dp"),
               requiredCoordinate(s"artifact$dp"),
               requiredCoordinateRaw(s"artifact$dp"),
-              requiredCoordinate(s"version$dp"),
+              if (bomSymbols.contains(versionCoordinate)) None else Some(versionCoordinate),
+              `type` = None,
               coordinate(s"scope$dp"),
-              coordinate(s"classifier$dp")
+              coordinate(s"classifier$dp"),
+              indent = "  "
             )
           }
 
-          ("xml", symbolProperties + artifacts.mkString("\n"))
+          ("xml", symbolProperties + bomArtifacts ++ artifacts.mkString("&lt;dependencies&gt\n", "", "&lt;/dependencies&gt;"))
       }
 
       printer.print(s"""<dt>$tool</dt>""")

--- a/docs/src/main/paradox/directives/dependencies.md
+++ b/docs/src/main/paradox/directives/dependencies.md
@@ -102,3 +102,53 @@ will be rendered as:
   artifact3="akka-http_$scala.binary.version$"
   version3="AkkaHttpVersion"
 }
+
+## Bill of Materials (BOM) for Maven and Gradle
+
+Similar to the symbolic version names above, [Maven BOMs](http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#bill-of-materials-bom-poms) can point to a BOM which specifies versions for dependencies and frees the local build from setting library versions for those dependencies.
+
+By specifying a `bomGroup`, `bomArtifact` and `bomVersionSymbols` the Maven and Gradle notations will show the notation to import the BOM and leave out the versions for the libraries using the listed symbols. If the BOM covers multiple different versions, list all symbols separated by commas.
+
+Note that the notation works just fine for sbt.
+
+This example (with empty lines for readability)
+
+```
+@@dependency[Maven,Gradle,sbt] {
+  bomGroup=com.typesafe.akka
+  bomArtifact=akka-with-http-bom_$scala.binary.version$
+  bomVersionSymbols=AkkaVersion,AkkaHttpVersion
+
+  symbol1=AkkaVersion
+  value1="2.6.13"
+
+  symbol2="AkkaHttpVersion"
+  value2="10.2.2"
+
+  group1="com.typesafe.akka"
+  artifact1="akka-stream_$scala.binary.version$"
+  version1="AkkaVersion"
+
+  group2="com.typesafe.akka"
+  artifact2="akka-http_$scala.binary.version$"
+  version2="AkkaHttpVersion"
+}
+```
+
+will be rendered as:
+
+@@dependency[Maven,Gradle,sbt] {
+  bomGroup=com.typesafe.akka
+  bomArtifact=akka-with-http-bom_$scala.binary.version$
+  bomVersionSymbols=AkkaVersion,AkkaHttpVersion
+  symbol1=AkkaVersion
+  value1="2.6.13"
+  symbol2="AkkaHttpVersion"
+  value2="10.2.2"
+  group1="com.typesafe.akka"
+  artifact1="akka-stream_$scala.binary.version$"
+  version1="AkkaVersion"
+  group2="com.typesafe.akka"
+  artifact2="akka-http_$scala.binary.version$"
+  version2="AkkaHttpVersion"
+}

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/DependencyDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/DependencyDirectiveSpec.scala
@@ -133,6 +133,45 @@ class DependencyDirectiveSpec extends MarkdownBaseSpec {
       |</dd>
       |</dl>""")
   }
+  it should "render test scope" in {
+    markdown("""
+               |@@dependency[sbt,Maven,Gradle] {
+               |  group="com.example"
+               |  artifact="domain"
+               |  version="0.1.0-RC2"
+               |  scope="test"
+               |}""") shouldEqual html("""
+      |<dl class="dependency">
+      |<dt>sbt</dt>
+      |<dd>
+      |<pre class="prettyprint">
+      |<code class="language-scala">
+      |libraryDependencies += "com.example" % "domain" % "0.1.0-RC2" % Test</code></pre>
+      |</dd>
+      |<dt>Maven</dt>
+      |<dd>
+      |<pre class="prettyprint">
+      |<code class="language-xml">
+      |&lt;dependencies&gt;
+      |  &lt;dependency&gt;
+      |    &lt;groupId&gt;com.example&lt;/groupId&gt;
+      |    &lt;artifactId&gt;domain&lt;/artifactId&gt;
+      |    &lt;version&gt;0.1.0-RC2&lt;/version&gt;
+      |    &lt;scope&gt;test&lt;/scope&gt;
+      |  &lt;/dependency&gt;
+      |&lt;/dependencies&gt;</code></pre>
+      |</dd>
+      |<dt>Gradle</dt>
+      |<dd>
+      |<pre class="prettyprint">
+      |<code class="language-gradle">
+      |dependencies {
+      |  testImplementation "com.example:domain:0.1.0-RC2"
+      |}</code>
+      |</pre>
+      |</dd>
+      |</dl>""")
+  }
 
   it should "only simplify sbt definition if the scalaBinaryVersion matches" in {
     markdown("""

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/DependencyDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/DependencyDirectiveSpec.scala
@@ -51,21 +51,23 @@ class DependencyDirectiveSpec extends MarkdownBaseSpec {
       |&lt;properties&gt;
       |  &lt;scala.binary.version&gt;2.12&lt;/scala.binary.version&gt;
       |&lt;/properties&gt;
-      |&lt;dependency&gt;
-      |  &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
-      |  &lt;artifactId&gt;akka-http_$${scala.binary.version}&lt;/artifactId&gt;
-      |  &lt;version&gt;10.0.10&lt;/version&gt;
-      |&lt;/dependency&gt;</code></pre>
+      |&lt;dependencies&gt;
+      |  &lt;dependency&gt;
+      |    &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
+      |    &lt;artifactId&gt;akka-http_$${scala.binary.version}&lt;/artifactId&gt;
+      |    &lt;version&gt;10.0.10&lt;/version&gt;
+      |  &lt;/dependency&gt;
+      |&lt;/dependencies&gt;</code></pre>
       |</dd>
       |<dt>Gradle</dt>
       |<dd>
       |<pre class="prettyprint">
       |<code class="language-gradle">
-      |versions += [
+      |def versions = [
       |  ScalaBinary: "2.12"
       |]
       |dependencies {
-      |  compile group: 'com.typesafe.akka', name: "akka-http_$${versions.ScalaBinary}", version: '10.0.10'
+      |  implementation "com.typesafe.akka:akka-http_$${versions.ScalaBinary}:10.0.10"
       |}</code>
       |</pre>
       |</dd>
@@ -110,20 +112,22 @@ class DependencyDirectiveSpec extends MarkdownBaseSpec {
       |<dd>
       |<pre class="prettyprint">
       |<code class="language-xml">
-      |&lt;dependency&gt;
-      |  &lt;groupId&gt;com.example&lt;/groupId&gt;
-      |  &lt;artifactId&gt;domain&lt;/artifactId&gt;
-      |  &lt;version&gt;0.1.0-RC2&lt;/version&gt;
-      |  &lt;classifier&gt;assets&lt;/classifier&gt;
-      |  &lt;scope&gt;runtime&lt;/scope&gt;
-      |&lt;/dependency&gt;</code></pre>
+      |&lt;dependencies&gt;
+      |  &lt;dependency&gt;
+      |    &lt;groupId&gt;com.example&lt;/groupId&gt;
+      |    &lt;artifactId&gt;domain&lt;/artifactId&gt;
+      |    &lt;version&gt;0.1.0-RC2&lt;/version&gt;
+      |    &lt;classifier&gt;assets&lt;/classifier&gt;
+      |    &lt;scope&gt;runtime&lt;/scope&gt;
+      |  &lt;/dependency&gt;
+      |&lt;/dependencies&gt;</code></pre>
       |</dd>
       |<dt>Gradle</dt>
       |<dd>
       |<pre class="prettyprint">
       |<code class="language-gradle">
       |dependencies {
-      |  runtime group: 'com.example', name: 'domain', version: '0.1.0-RC2', classifier: 'assets'
+      |  runtime "com.example:domain:0.1.0-RC2:assets"
       |}</code>
       |</pre>
       |</dd>
@@ -212,16 +216,18 @@ class DependencyDirectiveSpec extends MarkdownBaseSpec {
       |<dd>
       |<pre class="prettyprint">
       |<code class="language-xml">
-      |&lt;dependency&gt;
-      |  &lt;groupId&gt;org.example&lt;/groupId&gt;
-      |  &lt;artifactId&gt;foo_2.12&lt;/artifactId&gt;
-      |  &lt;version&gt;0.1.0&lt;/version&gt;
-      |&lt;/dependency&gt;
-      |&lt;dependency&gt;
-      |  &lt;groupId&gt;org.example&lt;/groupId&gt;
-      |  &lt;artifactId&gt;bar_2.12&lt;/artifactId&gt;
-      |  &lt;version&gt;0.2.0&lt;/version&gt;
-      |&lt;/dependency&gt;</code>
+      |&lt;dependencies&gt;
+      |  &lt;dependency&gt;
+      |    &lt;groupId&gt;org.example&lt;/groupId&gt;
+      |    &lt;artifactId&gt;foo_2.12&lt;/artifactId&gt;
+      |    &lt;version&gt;0.1.0&lt;/version&gt;
+      |  &lt;/dependency&gt;
+      |  &lt;dependency&gt;
+      |    &lt;groupId&gt;org.example&lt;/groupId&gt;
+      |    &lt;artifactId&gt;bar_2.12&lt;/artifactId&gt;
+      |    &lt;version&gt;0.2.0&lt;/version&gt;
+      |  &lt;/dependency&gt;
+      |&lt;/dependencies&gt;</code>
       |</pre>
       |</dd>
       |<dt>gradle</dt>
@@ -229,8 +235,8 @@ class DependencyDirectiveSpec extends MarkdownBaseSpec {
       |<pre class="prettyprint">
       |<code class="language-gradle">
       |dependencies {
-      |  compile group: 'org.example', name: 'foo_2.12', version: '0.1.0',
-      |  compile group: 'org.example', name: 'bar_2.12', version: '0.2.0'
+      |  implementation "org.example:foo_2.12:0.1.0"
+      |  implementation "org.example:bar_2.12:0.2.0"
       |}</code>
       |</pre>
       |</dd>
@@ -263,22 +269,24 @@ class DependencyDirectiveSpec extends MarkdownBaseSpec {
       |  &lt;akka.http.version&gt;10.1.0&lt;/akka.http.version&gt;
       |  &lt;scala.binary.version&gt;2.12&lt;/scala.binary.version&gt;
       |&lt;/properties&gt;
-      |&lt;dependency&gt;
-      |  &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
-      |  &lt;artifactId&gt;akka-http_$${scala.binary.version}&lt;/artifactId&gt;
-      |  &lt;version&gt;$${akka.http.version}&lt;/version&gt;
-      |&lt;/dependency&gt;</code></pre>
+      |&lt;dependencies&gt;
+      |  &lt;dependency&gt;
+      |    &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
+      |    &lt;artifactId&gt;akka-http_$${scala.binary.version}&lt;/artifactId&gt;
+      |    &lt;version&gt;$${akka.http.version}&lt;/version&gt;
+      |  &lt;/dependency&gt;
+      |&lt;/dependencies&gt;</code></pre>
       |</dd>
       |<dt>gradle</dt>
       |<dd>
       |<pre class="prettyprint">
       |<code class="language-gradle">
-      |versions += [
+      |def versions = [
       |  AkkaHttpVersion: "10.1.0",
       |  ScalaBinary: "2.12"
       |]
       |dependencies {
-      |  compile group: 'com.typesafe.akka', name: "akka-http_$${versions.ScalaBinary}", version: versions.AkkaHttpVersion
+      |  implementation "com.typesafe.akka:akka-http_$${versions.ScalaBinary}:$${versions.AkkaHttpVersion}"
       |}</code>
       |</pre>
       |</dd>
@@ -320,32 +328,173 @@ class DependencyDirectiveSpec extends MarkdownBaseSpec {
       |  &lt;akka.http.version&gt;10.1.0&lt;/akka.http.version&gt;
       |  &lt;scala.binary.version&gt;2.12&lt;/scala.binary.version&gt;
       |&lt;/properties&gt;
-      |&lt;dependency&gt;
-      |  &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
-      |  &lt;artifactId&gt;akka-stream_$${scala.binary.version}&lt;/artifactId&gt;
-      |  &lt;version&gt;$${akka.version}&lt;/version&gt;
-      |&lt;/dependency&gt;
-      |&lt;dependency&gt;
-      |  &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
-      |  &lt;artifactId&gt;akka-http_$${scala.binary.version}&lt;/artifactId&gt;
-      |  &lt;version&gt;$${akka.http.version}&lt;/version&gt;
-      |&lt;/dependency&gt;</code></pre>
+      |&lt;dependencies&gt;
+      |  &lt;dependency&gt;
+      |    &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
+      |    &lt;artifactId&gt;akka-stream_$${scala.binary.version}&lt;/artifactId&gt;
+      |    &lt;version&gt;$${akka.version}&lt;/version&gt;
+      |  &lt;/dependency&gt;
+      |  &lt;dependency&gt;
+      |    &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
+      |    &lt;artifactId&gt;akka-http_$${scala.binary.version}&lt;/artifactId&gt;
+      |    &lt;version&gt;$${akka.http.version}&lt;/version&gt;
+      |  &lt;/dependency&gt;
+      |&lt;/dependencies&gt;</code></pre>
       |</dd>
       |<dt>gradle</dt>
       |<dd>
       |<pre class="prettyprint">
       |<code class="language-gradle">
-      |versions += [
+      |def versions = [
       |  AkkaVersion: "2.5.29",
       |  AkkaHttpVersion: "10.1.0",
       |  ScalaBinary: "2.12"
       |]
       |dependencies {
-      |  compile group: 'com.typesafe.akka', name: "akka-stream_$${versions.ScalaBinary}", version: versions.AkkaVersion,
-      |  compile group: 'com.typesafe.akka', name: "akka-http_$${versions.ScalaBinary}", version: versions.AkkaHttpVersion
+      |  implementation "com.typesafe.akka:akka-stream_$${versions.ScalaBinary}:$${versions.AkkaVersion}"
+      |  implementation "com.typesafe.akka:akka-http_$${versions.ScalaBinary}:$${versions.AkkaHttpVersion}"
       |}</code>
       |</pre>
       |</dd>
       |</dl>""")
   }
+
+  it should "render bom import" in {
+    markdown("""
+               |@@dependency[sbt,Maven,gradle] {
+               |  bomGroup="com.typesafe.akka"
+               |  bomArtifact="akka-http-bom_$scala.binary.version$"
+               |  bomVersionSymbol="AkkaHttpVersion"
+               |  symbol="AkkaHttpVersion"
+               |  value="10.1.0"
+               |  group="com.typesafe.akka"
+               |  artifact="akka-http_$scala.binary.version$"
+               |  version="AkkaHttpVersion"
+               |}""") shouldEqual html(s"""
+      |<dl class="dependency">
+      |<dt>sbt</dt>
+      |<dd>
+      |<pre class="prettyprint">
+      |<code class="language-scala">
+      |val AkkaHttpVersion = "10.1.0"
+      |libraryDependencies += "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion</code></pre>
+      |</dd>
+      |<dt>Maven</dt>
+      |<dd>
+      |<pre class="prettyprint">
+      |<code class="language-xml">
+      |&lt;properties&gt;
+      |  &lt;scala.binary.version&gt;2.12&lt;/scala.binary.version&gt;
+      |&lt;/properties&gt;
+      |&lt;dependencyManagement&gt;
+      |  &lt;dependencies&gt;
+      |    &lt;dependency&gt;
+      |      &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
+      |      &lt;artifactId&gt;akka-http-bom_$${scala.binary.version}&lt;/artifactId&gt;
+      |      &lt;version&gt;10.1.0&lt;/version&gt;
+      |      &lt;type&gt;pom&lt;/type&gt;
+      |      &lt;scope&gt;import&lt;/scope&gt;
+      |    &lt;/dependency&gt;
+      |  &lt;/dependencies&gt;
+      |&lt;/dependencyManagement&gt;
+      |&lt;dependencies&gt;
+      |  &lt;dependency&gt;
+      |    &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
+      |    &lt;artifactId&gt;akka-http_$${scala.binary.version}&lt;/artifactId&gt;
+      |  &lt;/dependency&gt;
+      |&lt;/dependencies&gt;</code></pre>
+      |</dd>
+      |<dt>gradle</dt>
+      |<dd>
+      |<pre class="prettyprint">
+      |<code class="language-gradle">
+      |def versions = [
+      |  ScalaBinary: "2.12"
+      |]
+      |dependencies {
+      |  implementation platform("com.typesafe.akka:akka-http-bom_$${versions.ScalaBinary}:10.1.0")
+      |
+      |  implementation "com.typesafe.akka:akka-http_$${versions.ScalaBinary}"
+      |}</code>
+      |</pre>
+      |</dd>
+      |</dl>""")
+  }
+
+  it should "render multiple bom imports" in {
+    markdown("""
+               |@@dependency[Maven,gradle] {
+               |  bomGroup="com.typesafe.akka"
+               |  bomArtifact="akka-bom_$scala.binary.version$"
+               |  bomVersionSymbol="AkkaVersion"
+               |  bomGroup2="com.typesafe.akka"
+               |  bomArtifact2="akka-http-bom_$scala.binary.version$"
+               |  bomVersionSymbol2="AkkaHttpVersion"
+               |  symbol1="AkkaVersion"
+               |  value1="2.6.12"
+               |  group1="com.typesafe.akka"
+               |  symbol2="AkkaHttpVersion"
+               |  value2="10.1.0"
+               |  artifact1="akka-stream_$scala.binary.version$"
+               |  version1="AkkaVersion"
+               |  group2="com.typesafe.akka"
+               |  artifact2="akka-http_$scala.binary.version$"
+               |  version2="AkkaHttpVersion"
+               |}""") shouldEqual html(s"""
+      |<dl class="dependency">
+      |<dt>Maven</dt>
+      |<dd>
+      |<pre class="prettyprint">
+      |<code class="language-xml">
+      |&lt;properties&gt;
+      |  &lt;scala.binary.version&gt;2.12&lt;/scala.binary.version&gt;
+      |&lt;/properties&gt;
+      |&lt;dependencyManagement&gt;
+      |  &lt;dependencies&gt;
+      |    &lt;dependency&gt;
+      |      &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
+      |      &lt;artifactId&gt;akka-bom_$${scala.binary.version}&lt;/artifactId&gt;
+      |      &lt;version&gt;2.6.12&lt;/version&gt;
+      |      &lt;type&gt;pom&lt;/type&gt;
+      |      &lt;scope&gt;import&lt;/scope&gt;
+      |    &lt;/dependency&gt;
+      |    &lt;dependency&gt;
+      |      &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
+      |      &lt;artifactId&gt;akka-http-bom_$${scala.binary.version}&lt;/artifactId&gt;
+      |      &lt;version&gt;10.1.0&lt;/version&gt;
+      |      &lt;type&gt;pom&lt;/type&gt;
+      |      &lt;scope&gt;import&lt;/scope&gt;
+      |    &lt;/dependency&gt;
+      |  &lt;/dependencies&gt;
+      |&lt;/dependencyManagement&gt;
+      |&lt;dependencies&gt;
+      |  &lt;dependency&gt;
+      |    &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
+      |    &lt;artifactId&gt;akka-stream_$${scala.binary.version}&lt;/artifactId&gt;
+      |  &lt;/dependency&gt;
+      |  &lt;dependency&gt;
+      |    &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
+      |    &lt;artifactId&gt;akka-http_$${scala.binary.version}&lt;/artifactId&gt;
+      |  &lt;/dependency&gt;
+      |&lt;/dependencies&gt;</code></pre>
+      |</dd>
+      |<dt>gradle</dt>
+      |<dd>
+      |<pre class="prettyprint">
+      |<code class="language-gradle">
+      |def versions = [
+      |  ScalaBinary: "2.12"
+      |]
+      |dependencies {
+      |  implementation platform("com.typesafe.akka:akka-bom_$${versions.ScalaBinary}:2.6.12")
+      |  implementation platform("com.typesafe.akka:akka-http-bom_$${versions.ScalaBinary}:10.1.0")
+      |
+      |  implementation "com.typesafe.akka:akka-stream_$${versions.ScalaBinary}"
+      |  implementation "com.typesafe.akka:akka-http_$${versions.ScalaBinary}"
+      |}</code>
+      |</pre>
+      |</dd>
+      |</dl>""")
+  }
+
 }

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/DependencyDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/DependencyDirectiveSpec.scala
@@ -364,7 +364,7 @@ class DependencyDirectiveSpec extends MarkdownBaseSpec {
                |@@dependency[sbt,Maven,gradle] {
                |  bomGroup="com.typesafe.akka"
                |  bomArtifact="akka-http-bom_$scala.binary.version$"
-               |  bomVersionSymbol="AkkaHttpVersion"
+               |  bomVersionSymbols="AkkaHttpVersion"
                |  symbol="AkkaHttpVersion"
                |  value="10.1.0"
                |  group="com.typesafe.akka"
@@ -426,10 +426,10 @@ class DependencyDirectiveSpec extends MarkdownBaseSpec {
                |@@dependency[Maven,gradle] {
                |  bomGroup="com.typesafe.akka"
                |  bomArtifact="akka-bom_$scala.binary.version$"
-               |  bomVersionSymbol="AkkaVersion"
+               |  bomVersionSymbols="AkkaVersion"
                |  bomGroup2="com.typesafe.akka"
                |  bomArtifact2="akka-http-bom_$scala.binary.version$"
-               |  bomVersionSymbol2="AkkaHttpVersion"
+               |  bomVersionSymbols2="AkkaHttpVersion"
                |  symbol1="AkkaVersion"
                |  value1="2.6.12"
                |  group1="com.typesafe.akka"
@@ -488,6 +488,92 @@ class DependencyDirectiveSpec extends MarkdownBaseSpec {
       |dependencies {
       |  implementation platform("com.typesafe.akka:akka-bom_$${versions.ScalaBinary}:2.6.12")
       |  implementation platform("com.typesafe.akka:akka-http-bom_$${versions.ScalaBinary}:10.1.0")
+      |
+      |  implementation "com.typesafe.akka:akka-stream_$${versions.ScalaBinary}"
+      |  implementation "com.typesafe.akka:akka-http_$${versions.ScalaBinary}"
+      |}</code>
+      |</pre>
+      |</dd>
+      |</dl>""")
+  }
+
+  it should "Maven: allow for multiple symbolic versions in one bom" in {
+    markdown("""
+               |@@dependency[Maven] {
+               |  bomGroup="com.typesafe.akka"
+               |  bomArtifact="akka-bom_$scala.binary.version$"
+               |  bomVersionSymbols="AkkaVersion,AkkaHttpVersion"
+               |  symbol1="AkkaVersion"
+               |  value1="2.6.12"
+               |  group1="com.typesafe.akka"
+               |  symbol2="AkkaHttpVersion"
+               |  value2="10.1.0"
+               |  artifact1="akka-stream_$scala.binary.version$"
+               |  version1="AkkaVersion"
+               |  group2="com.typesafe.akka"
+               |  artifact2="akka-http_$scala.binary.version$"
+               |  version2="AkkaHttpVersion"
+               |}""") shouldEqual html(s"""
+      |<dl class="dependency">
+      |<dt>Maven</dt>
+      |<dd>
+      |<pre class="prettyprint">
+      |<code class="language-xml">
+      |&lt;properties&gt;
+      |  &lt;scala.binary.version&gt;2.12&lt;/scala.binary.version&gt;
+      |&lt;/properties&gt;
+      |&lt;dependencyManagement&gt;
+      |  &lt;dependencies&gt;
+      |    &lt;dependency&gt;
+      |      &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
+      |      &lt;artifactId&gt;akka-bom_$${scala.binary.version}&lt;/artifactId&gt;
+      |      &lt;version&gt;2.6.12&lt;/version&gt;
+      |      &lt;type&gt;pom&lt;/type&gt;
+      |      &lt;scope&gt;import&lt;/scope&gt;
+      |    &lt;/dependency&gt;
+      |  &lt;/dependencies&gt;
+      |&lt;/dependencyManagement&gt;
+      |&lt;dependencies&gt;
+      |  &lt;dependency&gt;
+      |    &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
+      |    &lt;artifactId&gt;akka-stream_$${scala.binary.version}&lt;/artifactId&gt;
+      |  &lt;/dependency&gt;
+      |  &lt;dependency&gt;
+      |    &lt;groupId&gt;com.typesafe.akka&lt;/groupId&gt;
+      |    &lt;artifactId&gt;akka-http_$${scala.binary.version}&lt;/artifactId&gt;
+      |  &lt;/dependency&gt;
+      |&lt;/dependencies&gt;</code></pre>
+      |</dd>
+      |</dl>""")
+  }
+
+  it should "Gradle: allow for multiple symbolic versions in one bom" in {
+    markdown("""
+               |@@dependency[gradle] {
+               |  bomGroup="com.typesafe.akka"
+               |  bomArtifact="akka-bom_$scala.binary.version$"
+               |  bomVersionSymbols="AkkaVersion,AkkaHttpVersion"
+               |  symbol1="AkkaVersion"
+               |  value1="2.6.12"
+               |  group1="com.typesafe.akka"
+               |  symbol2="AkkaHttpVersion"
+               |  value2="10.1.0"
+               |  artifact1="akka-stream_$scala.binary.version$"
+               |  version1="AkkaVersion"
+               |  group2="com.typesafe.akka"
+               |  artifact2="akka-http_$scala.binary.version$"
+               |  version2="AkkaHttpVersion"
+               |}""") shouldEqual html(s"""
+      |<dl class="dependency">
+      |<dt>gradle</dt>
+      |<dd>
+      |<pre class="prettyprint">
+      |<code class="language-gradle">
+      |def versions = [
+      |  ScalaBinary: "2.12"
+      |]
+      |dependencies {
+      |  implementation platform("com.typesafe.akka:akka-bom_$${versions.ScalaBinary}:2.6.12")
       |
       |  implementation "com.typesafe.akka:akka-stream_$${versions.ScalaBinary}"
       |  implementation "com.typesafe.akka:akka-http_$${versions.ScalaBinary}"


### PR DESCRIPTION
- Add support to render Maven and Gradle notation to reference Bill of Materials POMs.
- Update the Gradle notation to recent Gradle (`implementation` instead of `compile` scope, correct notation for the symbolic version map).
- Add the `<dependencies>` markers to the Maven notation to produce more copy-and-paste friendly XML.
