### PR TITLE
Code snippets now contain a button copying the contents

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/markdown/StyledVerbatim.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/StyledVerbatim.scala
@@ -47,9 +47,10 @@ abstract class StyledVerbatimSerializer extends VerbatimSerializer {
 
     node match {
       case vgn: VerbatimGroupNode =>
+        printer.print("""<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>""")
         vgn.getSourceUrl.ifPresent(new Consumer[String] {
           override def accept(sourceUrl: String): Unit =
-            printer.print(s"""<a class="icon go-to-source" href="$sourceUrl" target="_blank" title="Go to snippet source"></a>""")
+            printer.print(s"""<a class="snippet-button go-to-source" href="$sourceUrl" target="_blank" title="Go to snippet source">source</a>""")
         })
       case _ =>
     }

--- a/core/src/main/scala/com/lightbend/paradox/markdown/StyledVerbatim.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/StyledVerbatim.scala
@@ -48,11 +48,9 @@ abstract class StyledVerbatimSerializer extends VerbatimSerializer {
     node match {
       case vgn: VerbatimGroupNode =>
         printer.print("""<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>""")
-        printer.print("\n")
         vgn.getSourceUrl.ifPresent(new Consumer[String] {
           override def accept(sourceUrl: String): Unit = {
             printer.print(s"""<a class="snippet-button go-to-source" href="$sourceUrl" target="_blank" title="Go to snippet source">source</a>""")
-            printer.print("\n")
           }
         })
       case _ =>

--- a/core/src/main/scala/com/lightbend/paradox/markdown/StyledVerbatim.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/StyledVerbatim.scala
@@ -48,9 +48,12 @@ abstract class StyledVerbatimSerializer extends VerbatimSerializer {
     node match {
       case vgn: VerbatimGroupNode =>
         printer.print("""<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>""")
+        printer.print("\n")
         vgn.getSourceUrl.ifPresent(new Consumer[String] {
-          override def accept(sourceUrl: String): Unit =
+          override def accept(sourceUrl: String): Unit = {
             printer.print(s"""<a class="snippet-button go-to-source" href="$sourceUrl" target="_blank" title="Go to snippet source">source</a>""")
+            printer.print("\n")
+          }
         })
       case _ =>
     }

--- a/plugin/src/sbt-test/paradox/default-theme/expected/index.html
+++ b/plugin/src/sbt-test/paradox/default-theme/expected/index.html
@@ -12,6 +12,7 @@
 <script type="text/javascript" src="js/page.js"></script>
 <script type="text/javascript" src="js/warnOldVersion.js"></script>
 <script type="text/javascript" src="js/groups.js"></script>
+<script type="text/javascript" src="js/snippets.js"></script>
 <link rel="stylesheet" type="text/css" href="lib/foundation/dist/foundation.min.css"/>
 <link rel="stylesheet" type="text/css" href="css/page.css"/>
 

--- a/plugin/src/sbt-test/paradox/default-theme/expected/sub/indexed.html
+++ b/plugin/src/sbt-test/paradox/default-theme/expected/sub/indexed.html
@@ -12,6 +12,7 @@
 <script type="text/javascript" src="../js/page.js"></script>
 <script type="text/javascript" src="../js/warnOldVersion.js"></script>
 <script type="text/javascript" src="../js/groups.js"></script>
+<script type="text/javascript" src="../js/snippets.js"></script>
 <link rel="stylesheet" type="text/css" href="../lib/foundation/dist/foundation.min.css"/>
 <link rel="stylesheet" type="text/css" href="../css/page.css"/>
 

--- a/plugin/src/sbt-test/paradox/default-theme/expected/sub/unindexed.html
+++ b/plugin/src/sbt-test/paradox/default-theme/expected/sub/unindexed.html
@@ -12,6 +12,7 @@
 <script type="text/javascript" src="../js/page.js"></script>
 <script type="text/javascript" src="../js/warnOldVersion.js"></script>
 <script type="text/javascript" src="../js/groups.js"></script>
+<script type="text/javascript" src="../js/snippets.js"></script>
 <link rel="stylesheet" type="text/css" href="../lib/foundation/dist/foundation.min.css"/>
 <link rel="stylesheet" type="text/css" href="../css/page.css"/>
 

--- a/plugin/src/sbt-test/paradox/snippet-absolute/docs/expected/absolute.html
+++ b/plugin/src/sbt-test/paradox/snippet-absolute/docs/expected/absolute.html
@@ -1,1 +1,1 @@
-<pre class="prettyprint"><code class="language-scala">val snippet = 0</code></pre>
+<pre class="prettyprint"><button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">val snippet = 0</code></pre>

--- a/plugin/src/sbt-test/paradox/snippet-noindent-writer/expected/index.html
+++ b/plugin/src/sbt-test/paradox/snippet-noindent-writer/expected/index.html
@@ -1,6 +1,6 @@
 <div>
 <div>
-<pre class="prettyprint"><code class="language-scala">object Hello extends App {
+<pre class="prettyprint"><button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">object Hello extends App {
   def say(str: String): Unit = {
     println(str)
   }
@@ -10,7 +10,7 @@
 </div>
 </div>
 
-<pre class="prettyprint"><code class="language-scala">object Hello extends App {
+<pre class="prettyprint"><button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">object Hello extends App {
   def say(str: String): Unit = {
     println(str)
   }

--- a/plugin/src/sbt-test/paradox/snippets/expected/configured-bases.html
+++ b/plugin/src/sbt-test/paradox/snippets/expected/configured-bases.html
@@ -1,4 +1,4 @@
-<pre class="prettyprint"><code class="language-scala">val foo = 42</code></pre>
-<pre class="prettyprint"><code class="language-scala">val foo = 42</code></pre>
-<pre class="prettyprint"><code class="language-scala">val foo = 42</code></pre>
-<pre class="prettyprint"><code class="language-scala">val foo = 42</code></pre>
+<pre class="prettyprint"><button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">val foo = 42</code></pre>
+<pre class="prettyprint"><button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">val foo = 42</code></pre>
+<pre class="prettyprint"><button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">val foo = 42</code></pre>
+<pre class="prettyprint"><button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">val foo = 42</code></pre>

--- a/plugin/src/sbt-test/paradox/snippets/expected/group.html
+++ b/plugin/src/sbt-test/paradox/snippets/expected/group.html
@@ -1,2 +1,2 @@
-<pre class="prettyprint group-a"><code class="language-scala">private class SomethingElse</code></pre>
-<pre class="prettyprint group-b"><code class="language-scala">import scala.util.Try</code></pre>
+<pre class="prettyprint group-a"><button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">private class SomethingElse</code></pre>
+<pre class="prettyprint group-b"><button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">import scala.util.Try</code></pre>

--- a/plugin/src/sbt-test/paradox/snippets/expected/multiple.html
+++ b/plugin/src/sbt-test/paradox/snippets/expected/multiple.html
@@ -1,10 +1,10 @@
-<pre class="prettyprint"><code class="language-scala">import scala.concurrent.duration._
+<pre class="prettyprint"><button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">import scala.concurrent.duration._
 
 case class Measurement(method: Method, duration: Duration)</code></pre>
-<pre class="prettyprint"><code class="language-scala">import scala.util.Try
+<pre class="prettyprint"><button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">import scala.util.Try
 
 def parseInt(s: String): Option[Int] = Try(s.toInt).toOption</code></pre>
-<pre class="prettyprint"><code class="language-conf"># HTTP Configuration
+<pre class="prettyprint"><button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-conf"># HTTP Configuration
 http {
   port=80
   host=0.0.0.0

--- a/plugin/src/sbt-test/paradox/snippets/expected/nocode.html
+++ b/plugin/src/sbt-test/paradox/snippets/expected/nocode.html
@@ -1,4 +1,4 @@
-<pre class="prettyprint"><code class="nocode">certpath: -Using checker7 ... [sun.security.provider.certpath.RevocationChecker]
+<pre class="prettyprint"><button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="nocode">certpath: -Using checker7 ... [sun.security.provider.certpath.RevocationChecker]
 certpath: connecting to OCSP service at: http://gtssl2-ocsp.geotrust.com
 certpath: OCSP response status: SUCCESSFUL
 certpath: OCSP response type: basic

--- a/plugin/src/sbt-test/paradox/snippets/expected/reference.html
+++ b/plugin/src/sbt-test/paradox/snippets/expected/reference.html
@@ -1,4 +1,4 @@
-<pre class="prettyprint"><code class="language-conf"># This should be included
+<pre class="prettyprint"><button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-conf"># This should be included
 #and this as well
 
 snippets {
@@ -6,5 +6,5 @@ snippets {
   snip = &quot;snap&quot;
 }</code></pre>
 <!-- -->
-<pre class="prettyprint"><code class="language-conf"># this snip is a snap
+<pre class="prettyprint"><button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-conf"># this snip is a snap
 snip = &quot;snap&quot;</code></pre>

--- a/plugin/src/sbt-test/paradox/snippets/expected/snippets.html
+++ b/plugin/src/sbt-test/paradox/snippets/expected/snippets.html
@@ -1,8 +1,8 @@
-<pre class="prettyprint"><code class="language-scala">def indented = {
+<pre class="prettyprint"><button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">def indented = {
   1 + 2
 }</code></pre>
-<pre class="prettyprint"><code class="language-conf">snippets {
+<pre class="prettyprint"><button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-conf">snippets {
   test = 1
 }</code></pre>
-<pre class="prettyprint"><code class="language-scala">val symbols = Seq(&#39;symbols, Symbol(&quot;@&quot;), &#39;EOL)</code></pre>
-<pre class="prettyprint"><code class="language-scala">val spacy = &quot;Please do not remove ending spaces after these markers&quot;</code></pre>
+<pre class="prettyprint"><button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">val symbols = Seq(&#39;symbols, Symbol(&quot;@&quot;), &#39;EOL)</code></pre>
+<pre class="prettyprint"><button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">val spacy = &quot;Please do not remove ending spaces after these markers&quot;</code></pre>

--- a/plugin/src/sbt-test/paradox/snippets/expected/some-xml.html
+++ b/plugin/src/sbt-test/paradox/snippets/expected/some-xml.html
@@ -1,3 +1,3 @@
-<pre class="prettyprint"><code class="language-xml">&lt;bar&gt;
+<pre class="prettyprint"><button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-xml">&lt;bar&gt;
     XML FTW
 &lt;/bar&gt;</code></pre>

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/IncludeDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/IncludeDirectiveSpec.scala
@@ -53,6 +53,7 @@ class IncludeDirectiveSpec extends MarkdownBaseSpec {
   it should "include nested code snippets" in {
     markdown("""@@include(tests/src/test/resources/include-code-snip.md)""") shouldEqual html("""
       |<pre class="prettyprint">
+      |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
       |<code class="language-conf">
       |a = b</code>
       |</pre>""")

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/IncludeDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/IncludeDirectiveSpec.scala
@@ -53,8 +53,7 @@ class IncludeDirectiveSpec extends MarkdownBaseSpec {
   it should "include nested code snippets" in {
     markdown("""@@include(tests/src/test/resources/include-code-snip.md)""") shouldEqual html("""
       |<pre class="prettyprint">
-      |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
-      |<code class="language-conf">
+      |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-conf">
       |a = b</code>
       |</pre>""")
   }

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/SnipDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/SnipDirectiveSpec.scala
@@ -31,8 +31,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
   "The `snip` directive" should "render code snippets" in {
     markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #example }""") shouldEqual html("""
       |<pre class="prettyprint">
-      |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
-      |<code class="language-scala">
+      |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">
       |object example extends App {
       |  println("Hello, World!")
       |}</code>
@@ -51,8 +50,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
       |<dt>Scala</dt>
       |<dd>
       |<pre class="prettyprint">
-      |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
-      |<code class="language-scala">
+      |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">
       |object example extends App {
       |  println("Hello, World!")
       |}</code>
@@ -61,8 +59,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
       |<dt>Java</dt>
       |<dd>
       |<pre class="prettyprint">
-      |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
-      |<code class="language-java">
+      |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-java">
       |public class example2 {
       |    public static void main(String[] args) {
       |        System.out.println("Hello, World");
@@ -78,8 +75,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
       |@@snip[example2.java](tests/src/test/scala/com/lightbend/paradox/markdown/example2.java){ #example2 .red .blue }
       |""") shouldEqual html("""
       |<pre class="prettyprint red blue">
-      |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
-      |<code class="language-java">
+      |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-java">
       |public class example2 {
       |    public static void main(String[] args) {
       |        System.out.println("Hello, World");
@@ -91,8 +87,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
   it should "trim indentation from snippets" in {
     markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #indented-example }""") shouldEqual html("""
       |<pre class="prettyprint">
-      |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
-      |<code class="language-scala">
+      |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">
       |case object Dent
       |  case object DoubleDent</code>
       |</pre>""")
@@ -101,8 +96,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
   it should "not truncate snippets" in {
     markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #multi-indented-example }""") shouldEqual html("""
       |<pre class="prettyprint">
-      |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
-      |<code class="language-scala">
+      |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">
       |object AnotherIndentedExample {
       |  def rendered(): Unit = {
       |  }
@@ -120,9 +114,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
 
     markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #example }""") shouldEqual html(
       """<pre class="prettyprint">
-        |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
-        |<a class="snippet-button go-to-source" href="https://github.com/lightbend/paradox/tree/v0.2.1/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala#L28-L30" target="_blank" title="Go to snippet source">source</a>
-        |<code class="language-scala">
+        |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><a class="snippet-button go-to-source" href="https://github.com/lightbend/paradox/tree/v0.2.1/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala#L28-L30" target="_blank" title="Go to snippet source">source</a><code class="language-scala">
         |object example extends App {
         |  println("Hello, World!")
         |}</code>
@@ -139,9 +131,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
 
     markdown("""@@snip[example.scala]($test$/example.scala) { #example }""") shouldEqual html(
       """<pre class="prettyprint">
-        |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
-        |<a class="snippet-button go-to-source" href="https://github.com/lightbend/paradox/tree/v0.2.1/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala#L28-L30" target="_blank" title="Go to snippet source">source</a>
-        |<code class="language-scala">
+        |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><a class="snippet-button go-to-source" href="https://github.com/lightbend/paradox/tree/v0.2.1/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala#L28-L30" target="_blank" title="Go to snippet source">source</a><code class="language-scala">
         |object example extends App {
         |  println("Hello, World!")
         |}</code>
@@ -157,8 +147,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
 
     markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #example }""") shouldEqual html(
       """<pre class="prettyprint">
-        |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
-        |<code class="language-scala">
+        |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">
         |object example extends App {
         |  println("Hello, World!")
         |}</code>
@@ -168,8 +157,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
   it should "include labels when including the whole file" in {
     markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala)""") shouldEqual html(
       """<pre class="prettyprint">
-        |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
-        |<code class="language-scala">
+        |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">
         |/*
         | * Copyright &copy; 2015 - 2019 Lightbend, Inc. &lt;http://www.lightbend.com&gt;
         | *
@@ -259,8 +247,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
   it should "filter labels by default" in {
     markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #example-with-label }""") shouldEqual html(
       """<pre class="prettyprint">
-        |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
-        |<code class="language-scala">
+        |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">
         |object Constants {
         |}</code>
         |</pre>"""
@@ -270,8 +257,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
   it should "allow including labels if specified" in {
     markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #example-with-label filterLabels=false }""") shouldEqual html(
       """<pre class="prettyprint">
-        |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
-        |<code class="language-scala">
+        |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button><code class="language-scala">
         |object Constants {
         |  val someString = " #foo "
         |}</code>

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/SnipDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/SnipDirectiveSpec.scala
@@ -106,7 +106,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
       |</pre>""")
   }
 
-  it should "add link to source" in {
+  it should "add link to source and copy button" in {
     implicit val context = writerContextWithProperties(
       "github.base_url" -> "https://github.com/lightbend/paradox/tree/v0.2.1",
       "github.root.base_dir" -> new File(".").getAbsoluteFile.getParent,
@@ -114,7 +114,8 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
 
     markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #example }""") shouldEqual html(
       """<pre class="prettyprint">
-        |<a class="icon go-to-source" href="https://github.com/lightbend/paradox/tree/v0.2.1/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala#L28-L30" target="_blank" title="Go to snippet source"></a><code class="language-scala">
+        |<button class="snippet-button copy-snippet" title="Copy snippet">copy</a>
+        |<a class="snippet-button go-to-source" href="https://github.com/lightbend/paradox/tree/v0.2.1/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala#L28-L30" target="_blank" title="Go to snippet source"></a><code class="language-scala">
         |object example extends App {
         |  println("Hello, World!")
         |}</code>
@@ -131,7 +132,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
 
     markdown("""@@snip[example.scala]($test$/example.scala) { #example }""") shouldEqual html(
       """<pre class="prettyprint">
-        |<a class="icon go-to-source" href="https://github.com/lightbend/paradox/tree/v0.2.1/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala#L28-L30" target="_blank" title="Go to snippet source"></a><code class="language-scala">
+        |<a class="snippet-button go-to-source" href="https://github.com/lightbend/paradox/tree/v0.2.1/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala#L28-L30" target="_blank" title="Go to snippet source"></a><code class="language-scala">
         |object example extends App {
         |  println("Hello, World!")
         |}</code>

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/SnipDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/SnipDirectiveSpec.scala
@@ -31,6 +31,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
   "The `snip` directive" should "render code snippets" in {
     markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #example }""") shouldEqual html("""
       |<pre class="prettyprint">
+      |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
       |<code class="language-scala">
       |object example extends App {
       |  println("Hello, World!")
@@ -50,6 +51,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
       |<dt>Scala</dt>
       |<dd>
       |<pre class="prettyprint">
+      |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
       |<code class="language-scala">
       |object example extends App {
       |  println("Hello, World!")
@@ -59,6 +61,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
       |<dt>Java</dt>
       |<dd>
       |<pre class="prettyprint">
+      |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
       |<code class="language-java">
       |public class example2 {
       |    public static void main(String[] args) {
@@ -75,6 +78,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
       |@@snip[example2.java](tests/src/test/scala/com/lightbend/paradox/markdown/example2.java){ #example2 .red .blue }
       |""") shouldEqual html("""
       |<pre class="prettyprint red blue">
+      |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
       |<code class="language-java">
       |public class example2 {
       |    public static void main(String[] args) {
@@ -87,6 +91,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
   it should "trim indentation from snippets" in {
     markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #indented-example }""") shouldEqual html("""
       |<pre class="prettyprint">
+      |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
       |<code class="language-scala">
       |case object Dent
       |  case object DoubleDent</code>
@@ -96,6 +101,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
   it should "not truncate snippets" in {
     markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #multi-indented-example }""") shouldEqual html("""
       |<pre class="prettyprint">
+      |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
       |<code class="language-scala">
       |object AnotherIndentedExample {
       |  def rendered(): Unit = {
@@ -114,8 +120,9 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
 
     markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #example }""") shouldEqual html(
       """<pre class="prettyprint">
-        |<button class="snippet-button copy-snippet" title="Copy snippet">copy</a>
-        |<a class="snippet-button go-to-source" href="https://github.com/lightbend/paradox/tree/v0.2.1/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala#L28-L30" target="_blank" title="Go to snippet source"></a><code class="language-scala">
+        |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
+        |<a class="snippet-button go-to-source" href="https://github.com/lightbend/paradox/tree/v0.2.1/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala#L28-L30" target="_blank" title="Go to snippet source">source</a>
+        |<code class="language-scala">
         |object example extends App {
         |  println("Hello, World!")
         |}</code>
@@ -132,7 +139,9 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
 
     markdown("""@@snip[example.scala]($test$/example.scala) { #example }""") shouldEqual html(
       """<pre class="prettyprint">
-        |<a class="snippet-button go-to-source" href="https://github.com/lightbend/paradox/tree/v0.2.1/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala#L28-L30" target="_blank" title="Go to snippet source"></a><code class="language-scala">
+        |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
+        |<a class="snippet-button go-to-source" href="https://github.com/lightbend/paradox/tree/v0.2.1/tests/src/test/scala/com/lightbend/paradox/markdown/example.scala#L28-L30" target="_blank" title="Go to snippet source">source</a>
+        |<code class="language-scala">
         |object example extends App {
         |  println("Hello, World!")
         |}</code>
@@ -148,6 +157,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
 
     markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #example }""") shouldEqual html(
       """<pre class="prettyprint">
+        |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
         |<code class="language-scala">
         |object example extends App {
         |  println("Hello, World!")
@@ -158,6 +168,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
   it should "include labels when including the whole file" in {
     markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala)""") shouldEqual html(
       """<pre class="prettyprint">
+        |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
         |<code class="language-scala">
         |/*
         | * Copyright &copy; 2015 - 2019 Lightbend, Inc. &lt;http://www.lightbend.com&gt;
@@ -248,6 +259,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
   it should "filter labels by default" in {
     markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #example-with-label }""") shouldEqual html(
       """<pre class="prettyprint">
+        |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
         |<code class="language-scala">
         |object Constants {
         |}</code>
@@ -258,6 +270,7 @@ class SnipDirectiveSpec extends MarkdownBaseSpec {
   it should "allow including labels if specified" in {
     markdown("""@@snip[example.scala](tests/src/test/scala/com/lightbend/paradox/markdown/example.scala) { #example-with-label filterLabels=false }""") shouldEqual html(
       """<pre class="prettyprint">
+        |<button class="snippet-button copy-snippet" title="Copy snippet to clipboard">copy</button>
         |<code class="language-scala">
         |object Constants {
         |  val someString = " #foo "

--- a/themes/generic/src/main/assets/css/page.css
+++ b/themes/generic/src/main/assets/css/page.css
@@ -149,15 +149,23 @@ a.anchor .anchor-link:before {
   content: "§";
 }
 
-a.go-to-source::before {
-  content: "📄";
-}
-
-.prettyprint .icon {
+.prettyprint .snippet-button {
   float: right;
+  text-decoration: none;
+  font-size: 0.75rem;
+  font-weight: bold;
+  color: #4078c0;
+  border: 2px solid #e5e6e4;
+  padding: 4px 4px;
+  margin-left: 8px;
 }
 
-a.anchor .anchor-link, .icon {
+.prettyprint .snippet-button:hover {
+  background-color: #e5e6e4;
+  border: 2px solid #4078c0;
+}
+
+a.anchor .anchor-link, .snippet-button {
   font-size: 18px;
   font-family: "icons" !important;
   font-style: normal !important;

--- a/themes/generic/src/main/assets/css/page.css
+++ b/themes/generic/src/main/assets/css/page.css
@@ -149,23 +149,29 @@ a.anchor .anchor-link:before {
   content: "§";
 }
 
-.prettyprint .snippet-button {
+.site-content .page-content .prettyprint .snippet-button {
   float: right;
   text-decoration: none;
   font-size: 0.75rem;
   font-weight: bold;
+  font-family: "Roboto", "Helvetica Neue", "Helvetica", Arial, sans-serif;
+  speak: none;
   color: #4078c0;
   border: 2px solid #e5e6e4;
   padding: 4px 4px;
   margin-left: 8px;
+  line-height: 1.2;
+  vertical-align: middle;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-.prettyprint .snippet-button:hover {
+.site-content .page-content .prettyprint .snippet-button:hover {
   background-color: #e5e6e4;
   border: 2px solid #4078c0;
 }
 
-a.anchor .anchor-link, .snippet-button {
+a.anchor .anchor-link {
   font-size: 18px;
   font-family: "icons" !important;
   font-style: normal !important;

--- a/themes/generic/src/main/assets/js/snippets.js
+++ b/themes/generic/src/main/assets/js/snippets.js
@@ -1,0 +1,6 @@
+$(function() {
+  $(".snippet-button.copy-snippet").click(function() {
+    var code = $(this).parent().find("code").text()
+    navigator.clipboard.writeText(code)
+  })
+})

--- a/themes/generic/src/main/assets/page.st
+++ b/themes/generic/src/main/assets/page.st
@@ -14,6 +14,7 @@ $endif$
 <script type="text/javascript" src="$page.base$js/page.js"></script>
 <script type="text/javascript" src="$page.base$js/warnOldVersion.js"></script>
 <script type="text/javascript" src="$page.base$js/groups.js"></script>
+<script type="text/javascript" src="$page.base$js/snippets.js"></script>
 <link rel="stylesheet" type="text/css" href="$page.base$lib/foundation/dist/foundation.min.css"/>
 <link rel="stylesheet" type="text/css" href="$page.base$css/page.css"/>
 


### PR DESCRIPTION
Two text buttons up top right in snippets now: `[ source ]  [ copy ]`

This aligns the snippets with other doc tools that has a copy button up top right.