### PR TITLE
Don't override github.external_url if its already defined

### DIFF
--- a/docs/src/main/paradox/directives/linking.md
+++ b/docs/src/main/paradox/directives/linking.md
@@ -137,7 +137,9 @@ a tree revision, for example:
 <https://github.com/lightbend/paradox/tree/v0.2.1>.
 
 If the sbt project's `scmInfo` setting is configured and the `browseUrl`
-points to a GitHub project, it is used as the GitHub base URL.
+points to a GitHub project, it is used as the GitHub base URL. Note that this
+behaviour only occurs if `github.base_url` is not set so you still have the
+option to define `github.base_url` if this is not desirable.
 
 Relative as well as absolute file and directory paths use the value of the
 `github.root.base_dir` property to resolve the absolute project path. The sbt


### PR DESCRIPTION
So I came across a bug from a specific corner case when trying to integrate [github ref links](https://developer.lightbend.com/docs/paradox/current/directives/linking.html#github-directive) into one of my projects. After some debugging I found the state that causes the issue

1. Have `scmInfo` defined (in my case its because we use ghpages to publish the paradox site to github pages)
2. Define your own custom `github.external_url` in `paradoxProperties`. In my case this is done because we have a `main` branch rather than a `master` branch.

When I tried doing this in my project I noticed that no matter how I overrode `github.external_url` the setting would never applied, after looking into Paradox I found the offending code, i.e. https://github.com/lightbend/paradox/blob/master/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala#L427-L436

Basically if you have `scmInfo` defined then it will always override a custom defined `github.external_url` because the `linkProperties` just ignores `github.external_url` and returns a hardcoded `github.external_url` value that overrides the original.