### PR TITLE
Minor syntax improvements

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/markdown/Breadcrumbs.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Breadcrumbs.scala
@@ -32,8 +32,8 @@ object Breadcrumbs {
    */
   def markdown(leadingBreadcrumbs: List[(String, String)], locations: List[Location[Page]]): BulletListNode =
     locations match {
-      case current :: parents => crumbs(current.tree.label.base, current.tree.label.path, leadingBreadcrumbs, locations.reverse)
-      case _                  => list(Nil)
+      case current :: _ => crumbs(current.tree.label.base, current.tree.label.path, leadingBreadcrumbs, locations.reverse)
+      case _            => list(Nil)
     }
 
   private def crumbs(base: String, active: String, leadingBreadcrumbs: List[(String, String)], locations: List[Location[Page]]): BulletListNode = {

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Frontin.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Frontin.scala
@@ -18,6 +18,7 @@ package com.lightbend.paradox.markdown
 
 import java.io.{ File, StringReader }
 import collection.JavaConverters._
+import scala.io.BufferedSource
 
 case class Frontin(header: Map[String, String], body: String)
 
@@ -28,9 +29,13 @@ object Frontin {
     (str.trim == separator) && (str startsWith separator)
 
   def apply(file: File): Frontin = {
-    val source = scala.io.Source.fromFile(file)("UTF-8")
-    val lines = source.getLines.mkString("\n")
-    source.close()
+    var source: BufferedSource = null
+    val lines = try {
+      source = scala.io.Source.fromFile(file)("UTF-8")
+      source.getLines.mkString("\n")
+    } finally {
+      source.close()
+    }
     apply(lines)
   }
 

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Groups.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Groups.scala
@@ -17,7 +17,7 @@
 package com.lightbend.paradox.markdown
 
 object Groups {
-  def html(supergroups: Map[String, Seq[String]]) = {
+  def html(supergroups: Map[String, Seq[String]]): String = {
     supergroups.map {
       case (supergroup, groups) =>
         s"""<select class="supergroup" name="$supergroup">""" +

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Index.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Index.scala
@@ -145,7 +145,7 @@ object Index {
             Some(Ref(level, source.value, new TextNode(ref.label), group = None, Nil))
           case source: Source.Ref =>
             Some(Ref(level, source.value, new TextNode(ref.label), group = None, Nil))
-          case other =>
+          case _ =>
             sys.error(s"unexpected Source type: ${ref.source}")
         }
       case other => other.getChildren.asScala.toList match {
@@ -187,9 +187,7 @@ object Index {
     val pageMap = (pages map { page => page.path -> page }).toMap
 
     def lookup(current: String, path: String) = {
-      pageMap.get(Path.resolve(current, path)).getOrElse {
-        throw new LinkException(s"Unknown page [$path] linked from [$current]")
-      }
+      pageMap.getOrElse(Path.resolve(current, path), throw new LinkException(s"Unknown page [$path] linked from [$current]"))
     }
 
     def add(path: String, page: Page, indices: Forest[Ref], nested: Boolean): Unit = {

--- a/core/src/main/scala/com/lightbend/paradox/markdown/LinkCapturer.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/LinkCapturer.scala
@@ -154,11 +154,11 @@ class LinkCapturer {
 }
 
 case class CapturedLink(link: URI, fragments: List[CapturedLinkFragment]) {
-  def allSources = fragments.flatMap(_.sources)
+  def allSources: List[(File, Node)] = fragments.flatMap(_.sources)
 
-  def isInternal = link.getAuthority == null && link.getPath != null
+  def isInternal: Boolean = link.getAuthority == null && link.getPath != null
 
-  def hasFragments = fragments.size > 1 || fragments.headOption.flatMap(_.fragment).nonEmpty
+  def hasFragments: Boolean = fragments.size > 1 || fragments.headOption.flatMap(_.fragment).nonEmpty
 }
 
 case class CapturedLinkFragment(fragment: Option[String], sources: List[(File, Node)])

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Page.scala
@@ -17,7 +17,6 @@
 package com.lightbend.paradox.markdown
 
 import com.lightbend.paradox.tree.Tree.{ Forest, Location }
-import com.lightbend.paradox.template.PageTemplate
 import java.io.File
 import java.net.URI
 import java.nio.file.{ Path => NioPath, Paths => NioPaths }
@@ -58,7 +57,7 @@ case class Page(file: File, path: String, rootSrcPage: String, label: Node, h1: 
       node.getChildren.asScala.flatMap {
         case t: TextNode => Seq(t.getText)
         case other       => textNodes(other)
-      }.toSeq
+      }
     }
     textNodes(label).mkString
   }
@@ -137,15 +136,15 @@ object Page {
 
     // TODO: give the target suffix ".html" in a more general way
     private def replaceFile(prop: Option[String], targetSuffix: String = ".html")(path: String): Option[String] = prop match {
-      case Some(p) if (p.endsWith(targetSuffix)) => Some(path.dropRight(Path.leaf(path).length) + p)
-      case _                                     => None
+      case Some(p) if p.endsWith(targetSuffix) => Some(path.dropRight(Path.leaf(path).length) + p)
+      case _                                   => None
     }
   }
 
   object Properties {
-    val DefaultOutMdIndicator = "out"
-    val DefaultLayoutMdIndicator = "layout"
-    val DefaultSingleLayoutMdIndicator = "single-layout"
+    val DefaultOutMdIndicator: String = "out"
+    val DefaultLayoutMdIndicator: String = "layout"
+    val DefaultSingleLayoutMdIndicator: String = "single-layout"
   }
 
   /**
@@ -260,7 +259,7 @@ object Path {
     val rootPath = parentsPath(localPath)
     globalPageMappings map { mapping =>
       val rootMap = (parentsPath(mapping._1), parentsPath(mapping._2))
-      mapping._1 -> (refRelativePath(rootPath, rootMap._2, leaf(mapping._2)))
+      mapping._1 -> refRelativePath(rootPath, rootMap._2, leaf(mapping._2))
     }
   }
 
@@ -268,11 +267,12 @@ object Path {
    * Provide the modified path relative to the root path
    */
   def refRelativePath(root: List[String], path: List[String], leafFile: String): String = {
+    @tailrec
     def listPath(root: List[String], path: List[String]): List[String] = (root, path) match {
-      case (Nil, ps)                      => ps
-      case (rs, Nil)                      => rs map (_ => "..")
-      case (r :: rs, p :: ps) if (r == p) => listPath(rs, ps)
-      case _                              => root.map(_ => "..") ::: path
+      case (Nil, ps)                    => ps
+      case (rs, Nil)                    => rs map (_ => "..")
+      case (r :: rs, p :: ps) if r == p => listPath(rs, ps)
+      case _                            => root.map(_ => "..") ::: path
     }
     (listPath(root, path) ::: List(leafFile)).mkString("/")
   }

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Snippet.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Snippet.scala
@@ -125,8 +125,8 @@ object Snippet {
   }
 
   private case class ExtractionState(block: Block, lines: Seq[Line]) {
-    def snippetLines = lines.map(_._2)
-    def withBlock(block: Block) = copy(block = block)
+    def snippetLines: Seq[String] = lines.map(_._2)
+    def withBlock(block: Block): ExtractionState = copy(block = block)
   }
 
   private sealed trait Block

--- a/core/src/main/scala/com/lightbend/paradox/markdown/StyledVerbatim.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/StyledVerbatim.scala
@@ -18,7 +18,7 @@ package com.lightbend.paradox.markdown
 
 import java.util.function.Consumer
 
-import scala.collection.mutable.Buffer
+import scala.collection.mutable
 import scala.collection.JavaConverters._
 import org.parboiled.common.StringUtils
 import org.pegdown.ast.{ VerbatimGroupNode, VerbatimNode }
@@ -29,18 +29,18 @@ import org.pegdown.{ Printer, VerbatimSerializer }
  */
 abstract class StyledVerbatimSerializer extends VerbatimSerializer {
 
-  def printPreAttributes(printer: Printer, nodeGroup: String = "", classes: Buffer[String] = Buffer.empty[String]): Unit
+  def printPreAttributes(printer: Printer, nodeGroup: String = "", classes: mutable.Buffer[String] = mutable.Buffer.empty[String]): Unit
 
   def printCodeAttributes(printer: Printer, nodeType: String): Unit
 
-  def serialize(node: VerbatimNode, printer: Printer) = {
+  def serialize(node: VerbatimNode, printer: Printer): Unit = {
     printer.println()
 
     printer.print("<pre")
     if (!StringUtils.isEmpty(node.getType)) {
       node match {
         case vgn: VerbatimGroupNode => printPreAttributes(printer, vgn.getGroup, vgn.getClasses.asScala)
-        case vn: VerbatimNode       => printPreAttributes(printer)
+        case _: VerbatimNode        => printPreAttributes(printer)
       }
     }
     printer.print(">")
@@ -84,7 +84,7 @@ abstract class StyledVerbatimSerializer extends VerbatimSerializer {
  * Add prettify markup around verbatim blocks.
  */
 object PrettifyVerbatimSerializer extends StyledVerbatimSerializer {
-  override def printPreAttributes(printer: Printer, nodeGroup: String, classes: Buffer[String]): Unit = {
+  override def printPreAttributes(printer: Printer, nodeGroup: String, classes: mutable.Buffer[String]): Unit = {
     val allClasses = "prettyprint" +: (nodeGroup match {
       case "" => classes
       case g  => ("group-" + g) +: classes
@@ -100,7 +100,7 @@ object PrettifyVerbatimSerializer extends StyledVerbatimSerializer {
 
 object RawVerbatimSerializer extends VerbatimSerializer {
 
-  val tag = "raw"
+  val tag: String = "raw"
 
   override def serialize(node: VerbatimNode, printer: Printer): Unit = {
     printer.println()

--- a/core/src/main/scala/com/lightbend/paradox/markdown/TableOfContents.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/TableOfContents.scala
@@ -20,6 +20,8 @@ import com.lightbend.paradox.tree.Tree
 import com.lightbend.paradox.tree.Tree.{ Forest, Location }
 import org.pegdown.ast._
 
+import scala.annotation.tailrec
+
 /**
  * Create markdown list for table of contents on a page.
  */
@@ -82,6 +84,7 @@ class TableOfContents(pages: Boolean = true, headers: Boolean = true, ordered: B
    * Find the headers below the buffer index for a toc directive.
    * Return the level of the next header and sub-headers to render.
    */
+  @tailrec
   private def headersBelow(location: Option[Location[Header]], index: Int, includeIndexes: List[Int]): (Int, Forest[Header]) = location match {
     case Some(loc) =>
       if (isBelow(index, includeIndexes, loc.tree.label.label.getStartIndex, loc.tree.label.includeIndexes))
@@ -90,6 +93,7 @@ class TableOfContents(pages: Boolean = true, headers: Boolean = true, ordered: B
     case None => (0, Nil)
   }
 
+  @tailrec
   private def isBelow(tocIndex: Int, tocIncludeIndexes: List[Int], headerIndex: Int, headerIncludeIndexes: List[Int]): Boolean = {
     // If the current level of include indexes are equal, then we need to recursively check the next level.
     // Otherwise, we compare the current level of include indexes if they exist, or the current indexes themselves.
@@ -106,7 +110,7 @@ class TableOfContents(pages: Boolean = true, headers: Boolean = true, ordered: B
         val subHeaders = if (headers) items(base + page.path, active, page.headers, depth, expandDepth) else Nil
         val subPages = if (pages) items(base, active, tree.children, depth, expandDepth) else Nil
         optList(subHeaders ::: subPages)
-      case header: Header =>
+      case _: Header =>
         val subHeaders = if (headers) items(base, active, tree.children, depth, expandDepth) else Nil
         optList(subHeaders)
     }

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Url.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Url.scala
@@ -22,14 +22,14 @@ import java.net.{ URI, URISyntaxException }
  * Small wrapper around URI to help update individual components.
  */
 case class Url(base: URI) {
-  def withEndingSlash = base.getPath match {
+  def withEndingSlash: Url = base.getPath match {
     case path if path.endsWith("/index.html") => this
     case path                                 => copy(path = path + "/")
   }
   def /(path: String): Url = copy(path = base.getPath + "/" + path)
   def withQuery(query: String): Url = copy(query = query)
   def withFragment(fragment: String): Url = copy(fragment = fragment)
-  def copy(path: String = base.getPath, query: String = base.getQuery, fragment: String = base.getFragment) = {
+  def copy(path: String = base.getPath, query: String = base.getQuery, fragment: String = base.getFragment): Url = {
     val uri = new URI(base.getScheme, base.getUserInfo, base.getHost, base.getPort, path, query, fragment)
     Url(uri.normalize)
   }
@@ -48,14 +48,14 @@ object Url {
 
   def parse(base: String, msg: String): Url = {
     try Url(new URI(base)) catch {
-      case e: URISyntaxException =>
+      case _: URISyntaxException =>
         throw Url.Error(msg)
     }
   }
 }
 
 case class PropertyUrl(property: String, variables: String => Option[String]) {
-  def base = variables(property) match {
+  def base: String = variables(property) match {
     case Some(baseUrl) => baseUrl
     case None          => throw Url.Error(s"property [$property] is not defined")
   }
@@ -64,9 +64,9 @@ case class PropertyUrl(property: String, variables: String => Option[String]) {
     Url.parse(base, s"property [$property] contains an invalid URL [$base]")
   }
 
-  def format(args: String*) = Url(base.format(args: _*))
+  def format(args: String*): Url = Url(base.format(args: _*))
 
   def collect(f: PartialFunction[String, String]): Url = {
-    PropertyUrl(property, variables(_).collect(f)).resolve
+    PropertyUrl(property, variables(_).collect(f)).resolve()
   }
 }

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
@@ -22,8 +22,9 @@ import org.parboiled.common.StringUtils
 import org.pegdown.FastEncoder.encode
 import org.pegdown.plugins.ToHtmlSerializerPlugin
 import org.pegdown.ast._
-import org.pegdown.{ LinkRenderer, Printer, ToHtmlSerializer, VerbatimSerializer }
+import org.pegdown.{ LinkRenderer, ToHtmlSerializer, VerbatimSerializer }
 
+import java.util.regex.Pattern
 import scala.collection.JavaConverters._
 import scala.util.matching.Regex
 
@@ -91,9 +92,9 @@ class Writer(serializer: Writer.Context => ToHtmlSerializer) {
 
 object Writer {
 
-  val DefaultSourceSuffix = ".md"
-  val DefaultTargetSuffix = ".html"
-  val DefaultIllegalLinkPath =
+  val DefaultSourceSuffix: String = ".md"
+  val DefaultTargetSuffix: String = ".html"
+  val DefaultIllegalLinkPath: Regex =
     // #DefaultIllegalLinkPath
     raw"""^(?!https?:).*\.md(#.*)?""".r
   // #DefaultIllegalLinkPath
@@ -116,8 +117,8 @@ object Writer {
       properties:     Map[String, String]      = Map.empty,
       includeIndexes: List[Int]                = Nil
   ) {
-    val IllegalLinkPathPattern = linkFailPath.pattern
-    def page = location.tree.label
+    val IllegalLinkPathPattern: Pattern = linkFailPath.pattern
+    def page: Page = location.tree.label
   }
 
   def defaultLinks(context: Context): LinkRenderer =
@@ -131,8 +132,8 @@ object Writer {
   }
 
   def defaultPlugins(directives: Seq[Context => Directive]): Seq[Context => ToHtmlSerializerPlugin] = Seq(
-    context => new ClassyLinkSerializer,
-    context => new AnchorLinkSerializer,
+    _ => new ClassyLinkSerializer,
+    _ => new AnchorLinkSerializer,
     context => new DirectiveSerializer(directives.map(d => d(context))),
     context => new IncludeNodeSerializer(context)
   )
@@ -149,11 +150,11 @@ object Writer {
     context => TocDirective(context.location, context.includeIndexes),
     context => VarDirective(context.properties),
     context => VarsDirective(context.properties),
-    context => CalloutDirective("note", "Note"),
-    context => CalloutDirective("warning", "Warning"),
-    context => WrapDirective("div"),
-    context => InlineWrapDirective("span"),
-    context => InlineGroupDirective(context.groups.values.flatten.map(_.toLowerCase).toSeq),
+    _ => CalloutDirective("note", "Note"),
+    _ => CalloutDirective("warning", "Warning"),
+    _ => WrapDirective("div"),
+    _ => InlineWrapDirective("span"),
+    (context: Context) => InlineGroupDirective(context.groups.values.flatten.map(_.toLowerCase).toSeq),
     DependencyDirective.apply,
     IncludeDirective.apply
   )

--- a/core/src/main/scala/com/lightbend/paradox/template/PageTemplate.scala
+++ b/core/src/main/scala/com/lightbend/paradox/template/PageTemplate.scala
@@ -66,10 +66,14 @@ class PageTemplate(directory: File, val defaultName: String = "page", val defaul
         addVars(t)
       case None => sys.error(s"StringTemplate '$name' was not found for '$target'. Create a template or set a theme that contains one.")
     }
-    val osWriter = new OutputStreamWriter(new FileOutputStream(target), StandardCharsets.UTF_8)
-    val noIndentWriter = new NoIndentWriter(osWriter)
-    template.write(noIndentWriter)
-    osWriter.close()
+    var osWriter: OutputStreamWriter = null
+    try {
+      osWriter = new OutputStreamWriter(new FileOutputStream(target), StandardCharsets.UTF_8)
+      val noIndentWriter = new NoIndentWriter(osWriter)
+      template.write(noIndentWriter)
+    } finally {
+      osWriter.close()
+    }
     target
   }
 }


### PR DESCRIPTION
This PR applies syntax improvements that are the result of Intellij's default code inspections.

Some additional notes

* Intellij recommends adding type signatures to methods/fields which are public (hence the reason behind a lot of the addition of manual type annotations). I have the suspicion that a lot of these fields should actually be private and not public (likely the reason why the types were not there in the first place). If so let me know
* `Unit` type annotation was added to any method that happened to return `Unit` (i.e. side effecting methods that don't return anything).
* The various `.toSeq` conversions were removed since Intellij marked them as pointless (being the same type). I am quite sure this is not going to cause issues but I would double check here just to make sure nothing odd happens
* the `@tailrec` annotation doesn't actually change anything in the resulting generated bytecode but it will actually confirm that scalac will correctly translation the recursion into an efficient while loop.
* There were some cases where either `.close()` wasn't being called, or it was but the expression wasn't in a `try`/`finally` block which would mean if there is an exception (for some reason) then the handle's wouldn't be released. I have fixed these cases.