### PR TITLE
bump: update to parboiled 1.4.1 for JDK 17 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.15]
-        java: [temurin@8, temurin@11]
+        java: [temurin@8, temurin@11, temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -45,6 +45,13 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
+
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 17
 
       - name: Cache sbt
         uses: actions/cache@v2
@@ -102,6 +109,13 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
+
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 17
 
       - name: Cache sbt
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,20 +24,13 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.15]
-        java: [temurin@8, temurin@11, temurin@17]
+        java: [temurin@11, temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v2
-        with:
-          distribution: temurin
-          java-version: 8
 
       - name: Setup Java (temurin@11)
         if: matrix.java == 'temurin@11'
@@ -88,20 +81,13 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.15]
-        java: [temurin@8]
+        java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v2
-        with:
-          distribution: temurin
-          java-version: 8
 
       - name: Setup Java (temurin@11)
         if: matrix.java == 'temurin@11'

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,6 @@ inThisBuild(
 
 // https://github.com/djspiewak/sbt-github-actions
 ThisBuild / githubWorkflowJavaVersions := List(
-  JavaSpec.temurin("8"),
   JavaSpec.temurin("11"),
   JavaSpec.temurin("17")
 )

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,8 @@ inThisBuild(
 // https://github.com/djspiewak/sbt-github-actions
 ThisBuild / githubWorkflowJavaVersions := List(
   JavaSpec.temurin("8"),
-  JavaSpec.temurin("11")
+  JavaSpec.temurin("11"),
+  JavaSpec.temurin("17")
 )
 ThisBuild / githubWorkflowTargetBranches := Seq("master")
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Version {
   val foundation = "6.2.4"
   val jtidy      = "r938"
   val pegdown    = "1.6.0"
-  val parboiled  = "1.3.1"
+  val parboiled  = "1.4.1"
   val prettify   = "4-Mar-2013-1"
   val sbtWeb     = "1.4.4"
   val scalatest  = "3.2.12"


### PR DESCRIPTION
Refs #491. Tests with parboiled 1.4.1 work locally. Add JDK 17 to the build matrix.

**Note**: but parboiled 1.4.1 is built with JDK 11. So unless parboiled has a multi-release jar added or something, this would require making JDK 11 the minimum Java version for Paradox versions going forward as well.

Marking as draft for now, while we decide on the above.

