### PR TITLE
Expose property for relative source path

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
+++ b/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
@@ -461,6 +461,10 @@ class ParadoxProcessor(
     lazy val getAbsolute: PageLink =
       PageLink(location, location.map(_.root.tree.label).getOrElse(current), writer, context)
     lazy val isActive: Boolean = location.exists(active)
+    lazy val getRelative: String = location.map { l =>
+      val root = new File(".").getCanonicalFile.toString
+      Path.relativeLocalPath(root, l.tree.label.file.getPath)
+    }.orNull
 
     private def link(location: Location[Page]): String = {
       val node =


### PR DESCRIPTION
I'm using paradox from a Bitbucket repository and I'd like to make source links the way they exist for GitHub. Rather than making a specific property, I decided to try to piece the URL together from parts. The only part that I can't find a way to access is the relative path from the root of the repository to the markdown source file.

This change adds `relative` to `Page` so that, for example `$page.self.relative$` can be used.