### PR TITLE
Create a `repository` directive

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+pullRequests.frequency = "@monthly"
+
+commits.message = "bump: ${artifactName} ${nextVersion} (was ${currentVersion})"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-1. Wait until all running [Travis CI jobs](https://travis-ci.com/github/lightbend/paradox/builds) complete, if any.
+1. Wait until all running [GitHub Continuous Integration workflow](https://github.com/lightbend/paradox/actions/workflows/ci.yml) is complete, if any.
 1. Publish the [draft release](https://github.com/lightbend/paradox/releases) with a 'v0.x.y' tag
-1. Travis CI will start a [CI build](https://travis-ci.org/lightbend/paradox/builds) for the new tag and publish artifacts to Bintray and Sonatype.
+1. Have someone bake the release...
 1. Announce the new release in the [lightbend/paradox](https://gitter.im/lightbend/paradox) Gitter channel.

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Directive.scala
@@ -1060,7 +1060,7 @@ case class DependencyDirective(ctx: Writer.Context) extends LeafBlockDirective("
  * Repository directive.
  */
 case class RepositoryDirective(ctx: Writer.Context) extends LeafBlockDirective("repository") {
-  val variables: Map[String, String]     = ctx.properties
+  val variables: Map[String, String] = ctx.properties
 
   def render(node: DirectiveNode, visitor: Visitor, printer: Printer): Unit =
     node.contentsNode.getChildren.asScala.headOption match {
@@ -1071,8 +1071,8 @@ case class RepositoryDirective(ctx: Writer.Context) extends LeafBlockDirective("
   def renderRepository(tools: String, node: DirectiveNode, printer: Printer): Unit = {
     val classes = Seq("repository", node.attributes.classesString).filter(_.nonEmpty)
 
-    val startDelimiter           = node.attributes.value("start-delimiter", "$")
-    val stopDelimiter            = node.attributes.value("stop-delimiter", "$")
+    val startDelimiter = node.attributes.value("start-delimiter", "$")
+    val stopDelimiter  = node.attributes.value("stop-delimiter", "$")
 
     val postfixes = node.attributes
       .keys()
@@ -1101,7 +1101,7 @@ case class RepositoryDirective(ctx: Writer.Context) extends LeafBlockDirective("
         case "sbt" =>
           val repos = postfixes.map { p =>
             val name = requiredCoordinate(s"name$p")
-            val url = requiredCoordinate(s"url$p")
+            val url  = requiredCoordinate(s"url$p")
             s""""$name".at("$url")"""
           }
 
@@ -1130,9 +1130,9 @@ case class RepositoryDirective(ctx: Writer.Context) extends LeafBlockDirective("
 
         case "maven" | "Maven" | "mvn" =>
           val artifacts = postfixes.map { dp =>
-            val id = requiredCoordinate(s"id$dp")
+            val id   = requiredCoordinate(s"id$dp")
             val name = requiredCoordinate(s"name$dp")
-            val url = requiredCoordinate(s"url$dp")
+            val url  = requiredCoordinate(s"url$dp")
             s"""    &lt;repository&gt;
                |      &lt;id&gt;$id&lt;/id&gt;
                |      &lt;name>$name&lt;/name&gt;
@@ -1144,7 +1144,7 @@ case class RepositoryDirective(ctx: Writer.Context) extends LeafBlockDirective("
             "xml",
             "&lt;project&gt\n  ...\n  &lt;repositories&gt;\n" +
               artifacts.mkString +
-            "  &lt;/repositories&gt\n&lt;/project&gt;\n"
+              "  &lt;/repositories&gt\n&lt;/project&gt;\n"
           )
       }
       printer.print(s"""<dt>$tool</dt>""")

--- a/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
+++ b/core/src/main/scala/com/lightbend/paradox/markdown/Writer.scala
@@ -158,6 +158,7 @@ object Writer {
     _ => InlineWrapDirective("span"),
     (context: Context) => InlineGroupDirective(context.groups.values.flatten.map(_.toLowerCase).toSeq),
     DependencyDirective.apply,
+    RepositoryDirective.apply,
     IncludeDirective.apply
   )
 

--- a/docs/src/main/paradox/directives/index.md
+++ b/docs/src/main/paradox/directives/index.md
@@ -13,6 +13,7 @@ More directives are available via @ref[extensions](../customization/extensions.m
  * [Index and Table Of Contents Directives](organizing-pages.md)
  * [Linking Directives](linking.md)
  * [dependencies](dependencies.md)
+ * [repositories](repositories.md)
  * [Snippet Directives](snippets.md)
  * [Include Directives](includes.md)
  * [Fiddle Directives](fiddles.md)

--- a/docs/src/main/paradox/directives/repositories.md
+++ b/docs/src/main/paradox/directives/repositories.md
@@ -1,0 +1,21 @@
+Library repositories
+--------------------
+
+The `@@repository` block is used to show example code for how to configure a
+library repository in a build tool, such as sbt.
+
+```markdown
+@@dependency[sbt,Maven,Gradle] {
+  id="id1"
+  name="Company repository"
+  url="http://jars.acme.com"
+}
+```
+
+Which will render as:
+
+@@repository[sbt,Maven,Gradle] {
+  id="id1"
+  name="Company repository"
+  url="http://jars.acme.com"
+}

--- a/docs/src/main/paradox/directives/repositories.md
+++ b/docs/src/main/paradox/directives/repositories.md
@@ -5,8 +5,8 @@ The `@@repository` block is used to show example code for how to configure a
 library repository in a build tool, such as sbt.
 
 ```markdown
-@@dependency[sbt,Maven,Gradle] {
-  id="id1"
+@@repository[sbt,Maven,Gradle] {
+  id="company-repo"
   name="Company repository"
   url="http://jars.acme.com"
 }
@@ -15,7 +15,7 @@ library repository in a build tool, such as sbt.
 Which will render as:
 
 @@repository[sbt,Maven,Gradle] {
-  id="id1"
+  id="company-repo"
   name="Company repository"
   url="http://jars.acme.com"
 }

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/RepositoryDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/RepositoryDirectiveSpec.scala
@@ -78,8 +78,7 @@ class RepositoryDirectiveSpec extends MarkdownBaseSpec {
   }
 
   "Repository directive" should "render two repos" in {
-    markdown(
-      """
+    markdown("""
         |@@repository[sbt,Maven,gradle] {
         |  id1="id1"
         |  name1="Company repository"
@@ -87,8 +86,7 @@ class RepositoryDirectiveSpec extends MarkdownBaseSpec {
         |  id2="id-2"
         |  name2="Company repository 2"
         |  url2="http://uberjars.acme.com"
-        |}""") shouldEqual html(
-      s"""
+        |}""") shouldEqual html(s"""
          |<dl class="repository">
          |<dt>sbt</dt>
          |<dd>

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/RepositoryDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/RepositoryDirectiveSpec.scala
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2015 - 2019 Lightbend, Inc. <http://www.lightbend.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.paradox.markdown
+
+import com.lightbend.paradox.tree.Tree.Location
+
+class RepositoryDirectiveSpec extends MarkdownBaseSpec {
+
+  val testProperties = Map(
+    "project.version" -> "10.0.10",
+    "scala.version" -> "2.12.3",
+    "scala.binary.version" -> "2.12"
+  )
+
+  implicit val context: Location[Page] => Writer.Context = { loc =>
+    writerContext(loc).copy(properties = testProperties)
+  }
+
+  "Repository directive" should "render single repo" in {
+    markdown("""
+      |@@repository[sbt,Maven,gradle] {
+      |  id="id1"
+      |  name="Company repository"
+      |  url="http://jars.acme.com"
+      |}""") shouldEqual html(s"""
+      |<dl class="repository">
+      |<dt>sbt</dt>
+      |<dd>
+      |<pre class="prettyprint">
+      |<code class="language-scala">
+      |repositories += "Company repository".at("http://jars.acme.com")
+      |</code>
+      |</pre>
+      |</dd>
+      |<dt>Maven</dt>
+      |<dd>
+      |<pre class="prettyprint">
+      |<code class="language-xml">
+      |&lt;project&gt;
+      |  ...
+      |  &lt;repositories&gt;
+      |    &lt;repository&gt;
+      |      &lt;id&gt;id1&lt;/id&gt;
+      |      &lt;name&gt;Company repository&lt;/name&gt;
+      |      &lt;url&gt;http://jars.acme.com&lt;/url&gt;
+      |    &lt;/repository&gt;
+      |  &lt;/repositories&gt;
+      |&lt;/project&gt;
+      |</code></pre>
+      |</dd>
+      |<dt>gradle</dt>
+      |<dd>
+      |<pre class="prettyprint">
+      |<code class="language-gradle">
+      |repositories {
+      |    mavenCentral()
+      |    maven {
+      |        url "http://jars.acme.com"
+      |    }
+      |}
+      |</code></pre>
+      |</dd>
+      |</dl>""")
+  }
+
+  "Repository directive" should "render two repos" in {
+    markdown(
+      """
+        |@@repository[sbt,Maven,gradle] {
+        |  id1="id1"
+        |  name1="Company repository"
+        |  url1="http://jars.acme.com"
+        |  id2="id-2"
+        |  name2="Company repository 2"
+        |  url2="http://uberjars.acme.com"
+        |}""") shouldEqual html(
+      s"""
+         |<dl class="repository">
+         |<dt>sbt</dt>
+         |<dd>
+         |<pre class="prettyprint">
+         |<code class="language-scala">
+         |repositories ++= Seq(
+         |  "Company repository".at("http://jars.acme.com"),
+         |  "Company repository 2".at("http://uberjars.acme.com")
+         |)
+         |</code>
+         |</pre>
+         |</dd>
+         |<dt>Maven</dt>
+         |<dd>
+         |<pre class="prettyprint">
+         |<code class="language-xml">
+         |&lt;project&gt;
+         |  ...
+         |  &lt;repositories&gt;
+         |    &lt;repository&gt;
+         |      &lt;id&gt;id1&lt;/id&gt;
+         |      &lt;name&gt;Company repository&lt;/name&gt;
+         |      &lt;url&gt;http://jars.acme.com&lt;/url&gt;
+         |    &lt;/repository&gt;
+         |    &lt;repository&gt;
+         |      &lt;id&gt;id-2&lt;/id&gt;
+         |      &lt;name&gt;Company repository 2&lt;/name&gt;
+         |      &lt;url&gt;http://uberjars.acme.com&lt;/url&gt;
+         |    &lt;/repository&gt;
+         |  &lt;/repositories&gt;
+         |&lt;/project&gt;
+         |</code></pre>
+         |</dd>
+         |<dt>gradle</dt>
+         |<dd>
+         |<pre class="prettyprint">
+         |<code class="language-gradle">
+         |repositories {
+         |    mavenCentral()
+         |    maven {
+         |        url "http://jars.acme.com"
+         |    }
+         |    maven {
+         |        url "http://uberjars.acme.com"
+         |    }
+         |}
+         |</code></pre>
+         |</dd>
+         |</dl>""")
+  }
+
+}


### PR DESCRIPTION
Should make it easier to consistently show non-standard repositories

- https://maven.apache.org/guides/mini/guide-multiple-repositories.html#repository-order
- https://docs.gradle.org/current/userguide/declaring_repositories.html
- https://www.scala-sbt.org/1.x/docs/Resolvers.html