### PR TITLE
Explicitly state which external link failed to validate

### DIFF
--- a/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
+++ b/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
@@ -243,7 +243,7 @@ class ParadoxProcessor(
             .statusMessage()} on external link, location redirected to is [${response.header("Location")}]")
       } else if (response.statusCode() != 200) {
         close()
-        reportError(s"Error validating external link, status was ${response.statusCode()} ${response.statusMessage()}")
+        reportError(s"Error validating external link ${capturedLink.link}, status was ${response.statusCode()} ${response.statusMessage()}")
       } else {
         if (capturedLink.hasFragments) {
           validateFragments(url, response.parse(), capturedLink.fragments, errorContext)

--- a/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
+++ b/core/src/main/scala/com/lightbend/paradox/ParadoxProcessor.scala
@@ -243,7 +243,9 @@ class ParadoxProcessor(
             .statusMessage()} on external link, location redirected to is [${response.header("Location")}]")
       } else if (response.statusCode() != 200) {
         close()
-        reportError(s"Error validating external link ${capturedLink.link}, status was ${response.statusCode()} ${response.statusMessage()}")
+        reportError(
+          s"Error validating external link ${capturedLink.link}, status was ${response.statusCode()} ${response.statusMessage()}"
+        )
       } else {
         if (capturedLink.hasFragments) {
           validateFragments(url, response.parse(), capturedLink.fragments, errorContext)


### PR DESCRIPTION
During external link validation, the error message can be unhelpful:

```
[error] Error validating external link, status was 404 Not Found at /home/runner/work/nexus/nexus/docs/src/main/paradox/docs/faq.md:1
[error] # FAQ
[error] ^
```

This change explicitly states which link failed to validate 