### PR TITLE
ci: update workflows to target main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
   push:
-    branches: [master]
+    branches: [main]
     tags: [v*]
 
 env:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,6 +21,5 @@ jobs:
           fetch-depth: 0
 
       - name: Check project is formatted
-        uses: jrouly/scalafmt-native-action@v1
-        with:
-          version: '3.8.3'
+        # https://github.com/jrouly/scalafmt-native-action/releases
+        uses: jrouly/scalafmt-native-action@14620cde093e5ff6bfbbecd4f638370024287b9d # v4

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ ThisBuild / githubWorkflowJavaVersions := List(
   JavaSpec.temurin("11"),
   JavaSpec.temurin("17")
 )
-ThisBuild / githubWorkflowTargetBranches := Seq("master")
+ThisBuild / githubWorkflowTargetBranches := Seq("main")
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")
 ThisBuild / githubWorkflowPublishTargetBranches := Seq(RefPredicate.StartsWith(Ref.Tag("v")))
 ThisBuild / githubWorkflowPublish := Seq(


### PR DESCRIPTION
Just noticed that CI hasn't been running for a while, as we still had `master` branch.

Also update the scalafmt native action so that we don't need to manage that version (and scala steward can bump in the scalafmt config).