### PR TITLE
Try to make ci-release cross build work

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,6 @@ jobs:
       - env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          CI_RELEASE: ;^ core/publishSigned ;^ testkit/publishSigned ;^ plugin/publishSigned ;^ themePlugin/publishSigned ; genericTheme/publishSigned
           CI_CLEAN: clean
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
+    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,6 @@ ThisBuild / githubWorkflowPublish               := Seq(
     List("ci-release"),
     env = Map(
       "CI_CLEAN" -> "clean",
-      "CI_RELEASE" -> ";^ core/publishSigned ;^ testkit/publishSigned ;^ plugin/publishSigned ;^ themePlugin/publishSigned ; genericTheme/publishSigned",
       "PGP_PASSPHRASE" -> "${{ secrets.PGP_PASSPHRASE }}",
       "PGP_SECRET" -> "${{ secrets.PGP_SECRET }}",
       "SONATYPE_PASSWORD" -> "${{ secrets.SONATYPE_PASSWORD }}",

--- a/build.sbt
+++ b/build.sbt
@@ -50,8 +50,11 @@ ThisBuild / githubWorkflowBuild      := Seq(
 )
 ThisBuild / githubWorkflowTargetBranches := Seq("main")
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")
-ThisBuild / githubWorkflowPublishTargetBranches := Seq(RefPredicate.StartsWith(Ref.Tag("v")))
-ThisBuild / githubWorkflowPublish               := Seq(
+ThisBuild / githubWorkflowPublishTargetBranches := Seq(
+  RefPredicate.Equals(Ref.Branch("main")),
+  RefPredicate.StartsWith(Ref.Tag("v"))
+)
+ThisBuild / githubWorkflowPublish := Seq(
   WorkflowStep.Sbt(
     List("ci-release"),
     env = Map(

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -36,7 +36,7 @@ object Common extends AutoPlugin {
     scalacOptions ++= Seq("-encoding", "UTF-8", "-unchecked", "-deprecation", "-feature"),
     scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) => Seq("-Xsource:3")
+        case Some((2, _)) => Seq("-Xsource:3", "-release:11")
         case _            => Seq.empty
       }
     },

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/GitHubDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/GitHubDirectiveSpec.scala
@@ -77,13 +77,13 @@ class GitHubDirectiveSpec extends MarkdownBaseSpec {
       "github.root.base_dir" -> "."
     )
 
-    markdown("@github[See build.sbt](/build.sbt)")(context) shouldEqual
+    markdown("@github[See build.sbt](/build.sbt)")(using context) shouldEqual
       html("""<p><a href="https://github.com/lightbend/paradox/tree/master/build.sbt">See build.sbt</a></p>""")
   }
 
   it should "throw exceptions for unconfigured GitHub URL" in {
     the[ParadoxException] thrownBy {
-      markdown("@github[#1](#1)")(writerContext)
+      markdown("@github[#1](#1)")(using writerContext)
     } should have message "Failed to resolve [#1] because property [github.base_url] is not defined"
   }
 
@@ -92,11 +92,11 @@ class GitHubDirectiveSpec extends MarkdownBaseSpec {
       writerContextWithProperties("github.base_url" -> "https://github.com/project", "github.root.base_dir" -> ".")
 
     the[ParadoxException] thrownBy {
-      markdown("@github[#1](#1)")(invalidContext)
+      markdown("@github[#1](#1)")(using invalidContext)
     } should have message "Failed to resolve [#1] because [github.base_url] is not a project URL"
 
     the[ParadoxException] thrownBy {
-      markdown("@github[README.md](/README.md)")(invalidContext)
+      markdown("@github[README.md](/README.md)")(using invalidContext)
     } should have message "Failed to resolve [/README.md] because [github.base_url] is not a project or versioned tree URL"
   }
 
@@ -104,7 +104,7 @@ class GitHubDirectiveSpec extends MarkdownBaseSpec {
     val brokenContext = writerContextWithProperties("github.base_url" -> "https://github.com/broken/project|")
 
     the[ParadoxException] thrownBy {
-      markdown("@github[#1](#1)")(brokenContext)
+      markdown("@github[#1](#1)")(using brokenContext)
     } should have message "Failed to resolve [#1] because property [github.base_url] contains an invalid URL [https://github.com/broken/project|]"
   }
 

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/IndexSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/IndexSpec.scala
@@ -210,7 +210,7 @@ class IndexSpec extends MarkdownBaseSpec {
   }
 
   def indexed(mappings: (String, String)*): String =
-    show(pages(mappings: _*))
+    show(pages(mappings*))
 
   def index(text: String): String = prepare(text)
 

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/JavadocDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/JavadocDirectiveSpec.scala
@@ -143,7 +143,7 @@ class JavadocDirectiveSpec extends MarkdownBaseSpec {
 
   it should "throw exceptions for unconfigured default base URL" in {
     the[ParadoxException] thrownBy {
-      markdown("@javadoc[Model](org.example.Model)")(writerContext)
+      markdown("@javadoc[Model](org.example.Model)")(using writerContext)
     } should have message "Failed to resolve [org.example.Model] because property [javadoc.base_url] is not defined"
   }
 
@@ -171,7 +171,7 @@ class JavadocDirectiveSpec extends MarkdownBaseSpec {
 
   it should "support creating non frame style links" in {
     val ctx = context.andThen(c => c.copy(properties = c.properties.updated("javadoc.link_style", "direct")))
-    markdown("@javadoc[Publisher](org.reactivestreams.Publisher)")(ctx) shouldEqual
+    markdown("@javadoc[Publisher](org.reactivestreams.Publisher)")(using ctx) shouldEqual
       html(
         """<p><a href="http://www.reactive-streams.org/reactive-streams-1.0.0-javadoc/org/reactivestreams/Publisher.html" title="org.reactivestreams.Publisher"><code>Publisher</code></a></p>"""
       )
@@ -182,7 +182,7 @@ class JavadocDirectiveSpec extends MarkdownBaseSpec {
       c.copy(properties = c.properties.updated("javadoc.org.reactivestreams.link_style", "direct"))
     )
     markdown("""Frames: @javadoc:[Actor](akka.actor.Actor)
-               |Direct: @javadoc[Publisher](org.reactivestreams.Publisher)""".stripMargin)(ctx) shouldEqual
+               |Direct: @javadoc[Publisher](org.reactivestreams.Publisher)""".stripMargin)(using ctx) shouldEqual
       html(
         """<p>Frames: <a href="http://doc.akka.io/japi/akka/2.4.10/?akka/actor/Actor.html" title="akka.actor.Actor"><code>Actor</code></a>
           |Direct: <a href="http://www.reactive-streams.org/reactive-streams-1.0.0-javadoc/org/reactivestreams/Publisher.html" title="org.reactivestreams.Publisher"><code>Publisher</code></a></p>""".stripMargin
@@ -197,7 +197,7 @@ class JavadocDirectiveSpec extends MarkdownBaseSpec {
           .updated("javadoc.java.base_url", "https://docs.oracle.com/en/java/javase/11/docs/api/java.base/")
       )
     )
-    markdown("@javadoc:[Flow.Subscriber](java.util.concurrent.Flow.Subscriber)")(ctx) shouldEqual
+    markdown("@javadoc:[Flow.Subscriber](java.util.concurrent.Flow.Subscriber)")(using ctx) shouldEqual
       html(
         """<p><a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/Flow.Subscriber.html" title="java.util.concurrent.Flow.Subscriber"><code>Flow.Subscriber</code></a></p>"""
       )
@@ -211,7 +211,7 @@ class JavadocDirectiveSpec extends MarkdownBaseSpec {
           .updated("javadoc.akka.base_url", "https://doc.akka.io/japi/akka/current/")
       )
     )
-    markdown("@javadoc:[Effect.MessageAdapter](akka.actor.testkit.typed.Effect.MessageAdapter)")(ctx) shouldEqual
+    markdown("@javadoc:[Effect.MessageAdapter](akka.actor.testkit.typed.Effect.MessageAdapter)")(using ctx) shouldEqual
       html(
         """<p><a href="https://doc.akka.io/japi/akka/current/akka/actor/testkit/typed/Effect.MessageAdapter.html" title="akka.actor.testkit.typed.Effect.MessageAdapter"><code>Effect.MessageAdapter</code></a></p>"""
       )
@@ -224,7 +224,7 @@ class JavadocDirectiveSpec extends MarkdownBaseSpec {
           .updated("javadoc.org.example.package_name_style", "startWithAnycase")
       )
     )
-    markdown("@javadoc:[Outer.Inner](org.example.Lib.Outer$$Inner)")(ctx) shouldEqual
+    markdown("@javadoc:[Outer.Inner](org.example.Lib.Outer$$Inner)")(using ctx) shouldEqual
       renderedMd(
         "http://example.org/api/0.1.2/?org/example/Lib/Outer.Inner.html",
         "org.example.Lib.Outer.Inner",
@@ -248,7 +248,7 @@ class JavadocDirectiveSpec extends MarkdownBaseSpec {
           .updated("javadoc.org.example.package_name_style", "startWithAnycase")
       )
     )
-    markdown("@javadoc:[Outer.inner](org.example.lib.Outer$$inner)")(ctx) shouldEqual
+    markdown("@javadoc:[Outer.inner](org.example.lib.Outer$$inner)")(using ctx) shouldEqual
       renderedMd(
         "http://example.org/api/0.1.2/?org/example/lib/Outer.inner.html",
         "org.example.lib.Outer.inner",

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/PagePropertiesSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/PagePropertiesSpec.scala
@@ -20,7 +20,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class PagePropertiesSpec extends AnyFlatSpec with Matchers {
-  def convertPath = Path.replaceSuffix(".md", ".html") _
+  def convertPath: String => String = Path.replaceSuffix(".md", ".html")
 
   val propOut        = Map("out" -> "newIndex.html")
   val propNoOut      = Map.empty[String, String]

--- a/tests/src/test/scala/com/lightbend/paradox/markdown/ScaladocDirectiveSpec.scala
+++ b/tests/src/test/scala/com/lightbend/paradox/markdown/ScaladocDirectiveSpec.scala
@@ -139,7 +139,7 @@ class ScaladocDirectiveSpec extends MarkdownBaseSpec {
           .updated("scaladoc.org.example.package_name_style", "startWithAnycase")
       )
     )
-    markdown("@scaladoc:[Outer.Inner](org.example.Lib.Outer$$Inner)")(ctx) shouldEqual
+    markdown("@scaladoc:[Outer.Inner](org.example.Lib.Outer$$Inner)")(using ctx) shouldEqual
       renderedMd(
         "http://example.org/api/0.1.2/org/example/Lib/Outer$$Inner.html",
         "org.example.Lib.Outer.Inner",
@@ -163,7 +163,7 @@ class ScaladocDirectiveSpec extends MarkdownBaseSpec {
           .updated("scaladoc.org.example.package_name_style", "startWithAnycase")
       )
     )
-    markdown("@scaladoc:[Outer.inner](org.example.lib.Outer$$inner)")(ctx) shouldEqual
+    markdown("@scaladoc:[Outer.inner](org.example.lib.Outer$$inner)")(using ctx) shouldEqual
       renderedMd(
         "http://example.org/api/0.1.2/org/example/lib/Outer$$inner.html",
         "org.example.lib.Outer.inner",
@@ -194,7 +194,7 @@ class ScaladocDirectiveSpec extends MarkdownBaseSpec {
 
   it should "throw exceptions for unconfigured default base URL" in {
     the[ParadoxException] thrownBy {
-      markdown("@scaladoc[Model](org.example.Model)")(writerContext)
+      markdown("@scaladoc[Model](org.example.Model)")(using writerContext)
     } should have message "Failed to resolve [org.example.Model] because property [scaladoc.base_url] is not defined"
   }
 


### PR DESCRIPTION
- Fix more Scala 3 warnings
- ~Also test java 21 and 25~ not possible because of Parboiled can not read Java 21+ bytecode...
```
[info] com.lightbend.paradox.markdown.RepositoryDirectiveSpec *** ABORTED ***
[info]   java.lang.RuntimeException: Error creating extended parser class: Unsupported class file major version 65
[info]   at org.parboiled.Parboiled.createParser(Parboiled.java:58)
[info]   at com.lightbend.paradox.markdown.Reader.<init>(Reader.scala:42)
[info]   at com.lightbend.paradox.markdown.MarkdownTestkit.<init>(MarkdownTestkit.scala:31)
[info]   at com.lightbend.paradox.markdown.MarkdownBaseSpec.<init>(MarkdownBaseSpec.scala:22)
[info]   at com.lightbend.paradox.markdown.RepositoryDirectiveSpec.<init>(RepositoryDirectiveSpec.scala:21)
[info]   at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
[info]   at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
[info]   at java.base/java.lang.reflect.ReflectAccess.newInstance(ReflectAccess.java:128)
[info]   at java.base/jdk.internal.reflect.ReflectionFactory.newInstance(ReflectionFactory.java:304)
[info]   at java.base/java.lang.Class.newInstance(Class.java:727)
```
- Still target Java 11 for non Scala 3 artifacts
- Publish snapshots after merged into `main` branch
- Dependabot should take care of updating github actions
- Lets see if `sbt-ci-release` know what to do when `CI_RELEASE` is gone

@johanandren If for this repo snapshots are enabled in https://central.sonatype.com after merge a snapshot should be published so you do not need to tag it for now and we can just check the snapshot instead.
